### PR TITLE
Add copy-trader Compose + Turbo example

### DIFF
--- a/compose/copy-trader/.gitignore
+++ b/compose/copy-trader/.gitignore
@@ -1,0 +1,8 @@
+.compose/
+.env
+stage.db
+*.log
+node_modules/
+dist/
+.DS_Store
+restate-data/

--- a/compose/copy-trader/README.md
+++ b/compose/copy-trader/README.md
@@ -1,0 +1,143 @@
+# Copy Trader
+
+A [Compose](https://docs.goldsky.com/compose/introduction) + [Turbo](https://docs.goldsky.com/turbo/introduction) example that mirrors Polymarket trades from any set of wallets you choose. When a watched wallet buys or sells, the bot places the same side on the CLOB with a $1 notional.
+
+## How It Works
+
+```
+Polygon on-chain
+       │
+       └─ CTF Exchange + NegRisk Exchange: OrderFilled events
+            │
+            ▼
+  ┌──────────────────────┐
+  │  Turbo Pipeline      │  decode fills, filter to watched wallets
+  │  (polymarket-ctf-    │  → webhook per fill
+  │   events)            │
+  └──────────┬───────────┘
+             │
+             ▼
+  ┌──────────────────────┐
+  │  Compose App         │
+  ├──────────────────────┤
+  │  copy_trade (http)   │  sign + POST order to Polymarket CLOB
+  │  redeem (cron 5m)    │  redeem winning shares on-chain
+  │  setup_approvals     │  one-time USDC + CTF approvals
+  └──────────────────────┘
+```
+
+Fills are indexed by Turbo, webhooked to Compose, signed with an EOA key, and submitted to the CLOB through a Fly.io proxy (Polymarket's CLOB API is geo-blocked from US Compose hosts). Winning shares auto-redeem every 5 minutes.
+
+## Quick Start
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Pick wallets to copy and update both configs
+
+Edit `compose.yaml`:
+
+```yaml
+env:
+  cloud:
+    WATCHED_WALLETS: "0xwhale1,0xwhale2"
+```
+
+Edit `pipeline/polymarket-ctf-events.yaml` to match — the same addresses go in the `watched_fills` transform. The pipeline pre-filters on-chain, so the two lists must agree.
+
+### 3. Set your wallet's private key
+
+The Compose app signs CLOB orders as an EOA (no Polymarket proxy wallet needed):
+
+```bash
+goldsky compose secret set PRIVATE_KEY --value "0x..."
+```
+
+### 4. Create the webhook auth secret (one time per project)
+
+The Turbo webhook authenticates to your Compose app with this secret:
+
+```bash
+goldsky secret create --name COMPOSE_WEBHOOK_AUTH \
+  --value '{"type": "httpauth", "secretKey": "Authorization", "secretValue": "Bearer YOUR_COMPOSE_API_TOKEN"}'
+```
+
+### 5. Deploy the app and pipeline
+
+```bash
+goldsky compose deploy
+goldsky turbo apply pipeline/polymarket-ctf-events.yaml
+```
+
+### 6. Fund the wallet
+
+Send USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) on Polygon to your EOA. Compose sponsors gas, so no MATIC is required.
+
+### 7. Grant approvals
+
+One-time ERC-20 + ERC-1155 approvals to the CTF Exchange and NegRisk Exchange. Triggers four sponsored on-chain transactions:
+
+```bash
+curl -X POST -H "Authorization: Bearer $COMPOSE_TOKEN" \
+  https://api.goldsky.com/api/admin/compose/v1/copy-trader/tasks/setup_approvals
+```
+
+The bot starts trading as soon as a watched wallet's next fill hits the pipeline.
+
+## Project Structure
+
+```
+copy-trader/
+├── compose.yaml                           # Compose app + env config
+├── tsconfig.json                          # Compose type paths
+├── package.json                           # npm deps (bundled by Compose CLI)
+├── pipeline/
+│   └── polymarket-ctf-events.yaml         # Turbo pipeline → webhook sink
+└── src/
+    ├── lib/
+    │   ├── clob.ts                        # Polymarket CLOB client (ctx.fetch based)
+    │   ├── gamma.ts                       # Market metadata lookups
+    │   └── types.ts                       # Contract addresses + shared types
+    └── tasks/
+        ├── copy_trade.ts                  # HTTP: receive fill → mirror trade
+        ├── redeem.ts                      # Cron: redeem winning shares
+        └── setup_approvals.ts             # HTTP: one-time approvals
+```
+
+## Compose Features Demonstrated
+
+- **Turbo → Compose webhook** — a Turbo pipeline sinks decoded events to a Compose HTTP task
+- **Cron triggers** — `redeem` runs every 5 minutes
+- **`ctx.fetch`** — all outbound HTTP (Polymarket CLOB + Gamma + data API) goes through Compose's host-mediated fetch
+- **`ctx.evm.wallet` with sponsored gas** — on-chain calls (approvals, redemptions) use a Compose-sponsored wallet
+- **`ctx.collection`** — `positions` and `trades` collections for persistent state
+- **Secrets** — wallet private key stored via `goldsky compose secret set`
+
+## Customization
+
+### Trade size
+
+Default is Polymarket's $1 minimum notional. Raise it in `compose.yaml`:
+
+```yaml
+TRADE_AMOUNT_USD: "10"
+```
+
+### Use your own proxy
+
+`CLOB_HOST` defaults to a shared Goldsky-hosted Fly proxy. To isolate from it, deploy your own (see [`fly-polymarket-proxy`](https://github.com/goldsky-io/fly-polymarket-proxy)) and update `CLOB_HOST`.
+
+## Notes
+
+- The bot signs directly as the EOA. No Polymarket proxy wallet, no UI onboarding needed — just fund the EOA address with USDC.e.
+- `copy_trade` reads on-chain USDC balance before every BUY and skips if it would breach the $1.10 minimum. Local balance tracking isn't used — the chain is the source of truth.
+- `setup_approvals` is idempotent. Re-run it any time (e.g. after rotating keys) and it just re-emits the same `approve` / `setApprovalForAll` transactions.
+
+## Resources
+
+- [Compose Documentation](https://docs.goldsky.com/compose/introduction)
+- [Turbo Documentation](https://docs.goldsky.com/turbo/introduction)
+- [Polymarket CLOB API](https://docs.polymarket.com/)

--- a/compose/copy-trader/compose.yaml
+++ b/compose/copy-trader/compose.yaml
@@ -1,0 +1,40 @@
+name: "copy-trader"
+api_version: "stable"
+
+secrets:
+  - PRIVATE_KEY
+
+env:
+  cloud:
+    # ============ Required configuration ============
+    # Comma-separated wallets to copy. Must match the list in
+    # pipeline/polymarket-ctf-events.yaml.
+    WATCHED_WALLETS: "0xWALLET_1,0xWALLET_2"
+
+    # ============ Optional configuration ============
+    # Trade size per webhook. $1 is the Polymarket minimum notional.
+    TRADE_AMOUNT_USD: "1"
+
+    # Polymarket's CLOB API is geo-blocked in the US; the default Fly proxy
+    # forwards requests from an EU IP. Point at your own proxy if you prefer.
+    CLOB_HOST: "https://fly-polymarket-proxy.fly.dev"
+    GAMMA_HOST: "https://gamma-api.polymarket.com"
+
+tasks:
+  - name: "copy_trade"
+    path: "./src/tasks/copy_trade.ts"
+    triggers:
+      - type: "http"
+        authentication: "auth_token"
+
+  - name: "setup_approvals"
+    path: "./src/tasks/setup_approvals.ts"
+    triggers:
+      - type: "http"
+        authentication: "auth_token"
+
+  - name: "redeem"
+    path: "./src/tasks/redeem.ts"
+    triggers:
+      - type: "cron"
+        expression: "0 */5 * * * *"

--- a/compose/copy-trader/package-lock.json
+++ b/compose/copy-trader/package-lock.json
@@ -1,0 +1,1187 @@
+{
+  "name": "copy-trader",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "copy-trader",
+      "version": "0.1.0",
+      "dependencies": {
+        "@ethersproject/wallet": "^5.8.0",
+        "@polymarket/clob-client": "^5.1.3",
+        "viem": "^2.43.2"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/abstract-provider": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
+      "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/abstract-signer": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
+      "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/address": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
+      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/base64": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
+      "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/basex": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.8.0.tgz",
+      "integrity": "sha512-PIgTszMlDRmNwW9nhS6iqtVfdTAKosA7llYXNmGPw4YAI1PUyMv28988wAb41/gHF/WqGdoLv0erHaRcHRKW2Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
+      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
+      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/constants": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
+      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hash": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
+      "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/hdnode": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.8.0.tgz",
+      "integrity": "sha512-4bK1VF6E83/3/Im0ERnnUeWOY3P1BZml4ZD3wcH8Ys0/d1h1xaFt6Zc+Dh9zXf9TapGro0T4wvO71UTCp3/uoA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/json-wallets": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.8.0.tgz",
+      "integrity": "sha512-HxblNck8FVUtNxS3VTEYJAcwiKYsBIF77W15HufqlBF9gGfhmYOJtYZp8fSDZtn9y5EaXTE87zDwzxRoTFk11w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/pbkdf2": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "aes-js": "3.0.0",
+        "scrypt-js": "3.0.1"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
+      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
+      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
+      "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/pbkdf2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.8.0.tgz",
+      "integrity": "sha512-wuHiv97BrzCmfEaPbUFpMjlVg/IDkZThp9Ri88BpjRleg4iePJaj2SW8AIyE8cXn5V1tuAaMj6lzvsGJkGWskg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/properties": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
+      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/random": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
+      "integrity": "sha512-E4I5TDl7SVqyg4/kkA/qTfuLWAQGXmSOgYyO01So8hLfwgKvYK5snIlzxJMk72IFdG/7oh8yuSqY2KX7MMwg+A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
+      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/sha2": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.8.0.tgz",
+      "integrity": "sha512-dDOUrXr9wF/YFltgTBYS0tKslPEKr6AekjqDW2dbn1L1xmjGR+9GiKu4ajxovnrDbwxAKdHjW8jNcwfz8PAz4A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/signing-key": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
+      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "bn.js": "^5.2.1",
+        "elliptic": "6.6.1",
+        "hash.js": "1.1.7"
+      }
+    },
+    "node_modules/@ethersproject/strings": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
+      "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/transactions": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
+      "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wallet": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.8.0.tgz",
+      "integrity": "sha512-G+jnzmgg6UxurVKRKvw27h0kvG75YKXZKdlLYmAHeF32TGUzHkOFd7Zn6QHOTYRFWnfjtSSFjBowKo7vfrXzPA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/hdnode": "^5.8.0",
+        "@ethersproject/json-wallets": "^5.8.0",
+        "@ethersproject/keccak256": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/signing-key": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/wordlists": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/web": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
+      "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@ethersproject/wordlists": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.8.0.tgz",
+      "integrity": "sha512-2df9bbXicZws2Sb5S6ET493uJ0Z84Fjr3pC4tu/qlnZERibZCeUVuqdtt+7Tv9xxhUxHoIekIA7avrKUWHrezg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@polymarket/builder-signing-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@polymarket/builder-signing-sdk/-/builder-signing-sdk-1.0.0.tgz",
+      "integrity": "sha512-LNHc8Ox+2ITM6+VIEH5LH3SVh9ScE2mOUAJI789YfyNqhF4n1cNulk35Hb6IZfy1xtNfcEfNotanPLa/U8dCaw==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.12.2"
+      }
+    },
+    "node_modules/@polymarket/clob-client": {
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/@polymarket/clob-client/-/clob-client-5.8.1.tgz",
+      "integrity": "sha512-beKC4KPc9dYyFV9wFhKiGoA16q5xWz4PjkYcnEs3BzpsOKjGQGRlZQ7KQD4HQKUd3HC5RLQT0lqWHrFyaI+2fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@polymarket/builder-signing-sdk": "^1.0.0",
+        "axios": "^1.0.0",
+        "browser-or-node": "^2.1.1",
+        "viem": "^2.46.3"
+      },
+      "engines": {
+        "node": ">=20.10"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
+      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "license": "MIT"
+    },
+    "node_modules/browser-or-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
+      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/elliptic": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/elliptic/node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "license": "MIT"
+    },
+    "node_modules/ox": {
+      "version": "0.14.17",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.17.tgz",
+      "integrity": "sha512-jOzNb2Wlfzsr8z/GoCtd1bf6OSRuWuysvbhnHGD+7fV1WRbcBR6B0RYoe3xWnUedF7zp4l5APmS7CzAhUok/lA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.1.tgz",
+      "integrity": "sha512-GJC3gKV1Hngeo1IB9YanJKHH2pcmoqDymyPxddmzDtG8boXA7eFw8qdnn1PSaToJ93f3LpOZPlLLJ9beAF/Lzg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.17",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/compose/copy-trader/package.json
+++ b/compose/copy-trader/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "copy-trader",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Polymarket copy-trading example for Goldsky Compose + Turbo",
+  "dependencies": {
+    "@ethersproject/wallet": "^5.8.0",
+    "@polymarket/clob-client": "^5.1.3",
+    "viem": "^2.43.2"
+  }
+}

--- a/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
+++ b/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
@@ -1,0 +1,78 @@
+name: polymarket-ctf-events
+resource_size: s
+description: "Index Polymarket CTF Exchange fills for watched wallets → webhook to Compose"
+
+sources:
+  poly_logs:
+    type: dataset
+    dataset_name: matic.raw_logs
+    version: 1.0.0
+    start_at: latest
+    filter: >-
+      address IN (
+        '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e',
+        '0xc5d563a36ae78145c45a50134d48a1215220f80a'
+      )
+
+transforms:
+  decoded_fills:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT
+        id,
+        block_number,
+        log_index,
+        transaction_hash,
+        to_timestamp(block_timestamp) AS block_timestamp,
+        evm_log_decode(
+          '[{"anonymous":false,"inputs":[{"indexed":true,"name":"orderHash","type":"bytes32"},{"indexed":true,"name":"maker","type":"address"},{"indexed":true,"name":"taker","type":"address"},{"indexed":false,"name":"makerAssetId","type":"uint256"},{"indexed":false,"name":"takerAssetId","type":"uint256"},{"indexed":false,"name":"makerAmountFilled","type":"uint256"},{"indexed":false,"name":"takerAmountFilled","type":"uint256"},{"indexed":false,"name":"fee","type":"uint256"}],"name":"OrderFilled","type":"event"}]',
+          topics,
+          `data`
+        ) AS `decoded`
+      FROM poly_logs
+
+  order_fills:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT
+        id,
+        block_number,
+        log_index,
+        transaction_hash,
+        block_timestamp,
+        LOWER(`decoded`.event_params[2]) AS maker,
+        LOWER(`decoded`.event_params[3]) AS taker,
+        `decoded`.event_params[4] AS maker_asset_id,
+        `decoded`.event_params[5] AS taker_asset_id,
+        CAST(`decoded`.event_params[6] AS DOUBLE) / 1e6 AS maker_amount,
+        CAST(`decoded`.event_params[7] AS DOUBLE) / 1e6 AS taker_amount,
+        CAST(`decoded`.event_params[8] AS DOUBLE) / 1e6 AS fee
+      FROM decoded_fills
+      WHERE `decoded`.event_signature = 'OrderFilled'
+
+  # Filter to only watched wallets. REPLACE these with your own addresses —
+  # the list must match WATCHED_WALLETS in compose.yaml.
+  watched_fills:
+    type: sql
+    primary_key: id
+    sql: |
+      SELECT * FROM order_fills
+      WHERE maker IN (
+        '0xWALLET_1',
+        '0xWALLET_2'
+      )
+      OR taker IN (
+        '0xWALLET_1',
+        '0xWALLET_2'
+      )
+
+sinks:
+  # If you rename the Compose app, update the path segment below to match.
+  copy_trade_webhook:
+    type: webhook
+    from: watched_fills
+    url: https://api.goldsky.com/api/admin/compose/v1/copy-trader/tasks/copy_trade
+    secret_name: COMPOSE_WEBHOOK_AUTH
+    one_row_per_request: true

--- a/compose/copy-trader/src/lib/clob.ts
+++ b/compose/copy-trader/src/lib/clob.ts
@@ -1,0 +1,180 @@
+/**
+ * Minimal Polymarket CLOB client that uses ctx.fetch for all HTTP.
+ *
+ * The @polymarket/clob-client SDK uses axios, which fails under Compose's
+ * Deno runtime (no --allow-net on task binaries). We reuse the SDK's pure
+ * signing utilities (no HTTP) and route every API call through ctx.fetch,
+ * which bridges to the host process that has network permissions.
+ *
+ * All requests are made to CLOB_HOST, which should point at our Fly.io
+ * proxy in Frankfurt (clob.polymarket.com is geo-blocked from US-hosted
+ * Compose tasks).
+ */
+import type { TaskContext } from "compose";
+import { Wallet } from "@ethersproject/wallet";
+import { OrderBuilder } from "@polymarket/clob-client/dist/order-builder/builder.js";
+import { orderToJson } from "@polymarket/clob-client/dist/utilities.js";
+import { Side, OrderType, SignatureType } from "@polymarket/clob-client";
+import type { TickSize } from "@polymarket/clob-client";
+import { createL1Headers, createL2Headers } from "@polymarket/clob-client/dist/headers/index.js";
+
+const CHAIN_ID = 137;
+
+type ApiCreds = { key: string; secret: string; passphrase: string };
+
+let cachedCreds: ApiCreds | null = null;
+
+function normalizePk(pk: string): `0x${string}` {
+  return (pk.startsWith("0x") ? pk : `0x${pk}`) as `0x${string}`;
+}
+
+/**
+ * Fetch (or derive) the L2 API credentials for this wallet.
+ * Uses L1 EIP-712 auth headers; POST /auth/api-key creates, GET /auth/derive-api-key fetches existing.
+ */
+export async function getApiCreds(
+  ctx: TaskContext,
+  privateKey: string,
+  host: string
+): Promise<ApiCreds> {
+  if (cachedCreds) return cachedCreds;
+
+  const wallet = new Wallet(normalizePk(privateKey));
+  const l1Headers = await createL1Headers(wallet as any, CHAIN_ID);
+
+  // Try create first; if already exists (empty key), fall back to derive
+  try {
+    const created = (await ctx.fetch(`${host}/auth/api-key`, {
+      method: "POST",
+      headers: l1Headers as Record<string, string>,
+    })) as { apiKey?: string; secret?: string; passphrase?: string };
+
+    if (created?.apiKey) {
+      cachedCreds = {
+        key: created.apiKey,
+        secret: created.secret!,
+        passphrase: created.passphrase!,
+      };
+      return cachedCreds;
+    }
+  } catch {
+    // fall through to derive
+  }
+
+  const derived = (await ctx.fetch(`${host}/auth/derive-api-key`, {
+    method: "GET",
+    headers: l1Headers as Record<string, string>,
+  })) as { apiKey: string; secret: string; passphrase: string };
+
+  cachedCreds = {
+    key: derived.apiKey,
+    secret: derived.secret,
+    passphrase: derived.passphrase,
+  };
+  return cachedCreds;
+}
+
+export type TradeResult = {
+  success: boolean;
+  orderId?: string;
+  error?: string;
+};
+
+/**
+ * Build, sign, and submit a FAK (Fill-and-Kill) market order to the CLOB.
+ * All HTTP goes through ctx.fetch to the host → proxy → CLOB.
+ */
+export async function executeTrade(
+  ctx: TaskContext,
+  privateKey: string,
+  host: string,
+  tokenId: string,
+  side: "BUY" | "SELL",
+  amountUsd: number,
+  whalePrice: number,
+  tickSize: string,
+  negRisk: boolean,
+  feeRateBps: number,
+  sellSize?: number
+): Promise<TradeResult> {
+  try {
+    if (!whalePrice || whalePrice <= 0 || whalePrice >= 1) {
+      return { success: false, error: `Invalid whale price: ${whalePrice}` };
+    }
+
+    // Round to tick size and compute size/amount matching SDK conventions
+    const tick = parseFloat(tickSize) || 0.01;
+    const price = Math.round(whalePrice / tick) * tick;
+
+    // For BUY: smallest order that satisfies Polymarket's $1 minimum notional.
+    // For SELL: sell everything we hold (mirrors the whale exiting).
+    const shares =
+      side === "SELL"
+        ? Math.floor(sellSize ?? 0)
+        : Math.max(1, Math.ceil(1 / price));
+
+    if (shares < 1) {
+      return { success: false, error: `size too small (${shares})` };
+    }
+
+    // SDK's `amount` param for createMarketOrder:
+    //   BUY: USDC to spend (shares * price)
+    //   SELL: shares to sell
+    const amount = side === "BUY" ? shares * price : shares;
+
+    const wallet = new Wallet(normalizePk(privateKey));
+    const builder = new OrderBuilder(
+      wallet as any,
+      CHAIN_ID,
+      SignatureType.EOA
+    );
+
+    console.log(
+      `[clob] ${side} ${shares} shares @ ${price} (notional=$${(shares * price).toFixed(2)})`
+    );
+
+    // Build + sign the order locally (pure crypto, no HTTP)
+    const signedOrder = await builder.buildMarketOrder(
+      {
+        tokenID: tokenId,
+        price,
+        amount,
+        side: side === "BUY" ? Side.BUY : Side.SELL,
+        feeRateBps,
+      } as any,
+      { tickSize: tickSize as TickSize, negRisk }
+    );
+
+    const creds = await getApiCreds(ctx, privateKey, host);
+    const body = orderToJson(signedOrder, creds.key, OrderType.FAK);
+    const bodyStr = JSON.stringify(body);
+
+    const l2Headers = await createL2Headers(
+      wallet as any,
+      creds,
+      { method: "POST", requestPath: "/order", body: bodyStr }
+    );
+
+    const resp = (await ctx.fetch(`${host}/order`, {
+      method: "POST",
+      headers: {
+        ...l2Headers,
+        "Content-Type": "application/json",
+      } as Record<string, string>,
+      body: bodyStr,
+    })) as {
+      orderID?: string;
+      orderId?: string;
+      errorMsg?: string;
+      error?: string;
+    };
+
+    const orderId = resp.orderID || resp.orderId;
+    const errorMsg = resp.errorMsg || resp.error;
+
+    if (errorMsg) return { success: false, error: errorMsg, orderId };
+    return { success: true, orderId };
+  } catch (err) {
+    return { success: false, error: String(err) };
+  }
+}

--- a/compose/copy-trader/src/lib/gamma.ts
+++ b/compose/copy-trader/src/lib/gamma.ts
@@ -1,0 +1,66 @@
+/**
+ * Gamma API client for Polymarket market lookups.
+ * Maps token IDs to market details needed for CLOB trading.
+ */
+import type { TaskContext } from "compose";
+import type { MarketInfo } from "./types";
+
+/**
+ * Look up market details by CLOB token ID.
+ * Uses ctx.fetch (Compose's built-in HTTP client).
+ */
+export async function lookupMarketByTokenId(
+  fetch: TaskContext["fetch"],
+  gammaHost: string,
+  tokenId: string
+): Promise<MarketInfo | null> {
+  try {
+    const resp = await fetch(
+      `${gammaHost}/markets?clob_token_ids=${encodeURIComponent(tokenId)}`
+    );
+    const markets = resp as any[];
+    if (!markets?.length) return null;
+
+    const m = markets[0];
+    const clobTokenIds = JSON.parse(m.clobTokenIds || "[]");
+    const outcomePrices = JSON.parse(m.outcomePrices || "[0,0]");
+
+    return {
+      tokenId,
+      conditionId: m.conditionId,
+      question: m.question,
+      tickSize: m.orderPriceMinTickSize?.toString() || "0.01",
+      // `negRisk` is the flag we want (NegRisk Exchange routing).
+      // `negRiskOther` is unrelated (refers to companion markets in multi-outcome events).
+      negRisk: m.negRisk === true,
+      enableOrderBook: m.enableOrderBook === true,
+      closed: m.closed === true,
+      feeRateBps: m.takerBaseFee ?? 0,
+      outcomePrices: [
+        parseFloat(outcomePrices[0]) || 0,
+        parseFloat(outcomePrices[1]) || 0,
+      ],
+      clobTokenIds: [clobTokenIds[0] || "", clobTokenIds[1] || ""],
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check if a market is resolved (closed with a clear winner).
+ */
+export function isResolved(market: MarketInfo): boolean {
+  if (!market.closed) return false;
+  return market.outcomePrices[0] >= 0.99 || market.outcomePrices[1] >= 0.99;
+}
+
+/**
+ * Get the winning outcome index (0 = YES, 1 = NO).
+ */
+export function winningOutcomeIndex(market: MarketInfo): number | null {
+  if (!market.closed) return null;
+  if (market.outcomePrices[0] >= 0.99) return 0;
+  if (market.outcomePrices[1] >= 0.99) return 1;
+  return null;
+}

--- a/compose/copy-trader/src/lib/types.ts
+++ b/compose/copy-trader/src/lib/types.ts
@@ -1,0 +1,65 @@
+/** Polymarket contract addresses on Polygon */
+export const CONTRACTS = {
+  ctfExchange: "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E",
+  negRiskExchange: "0xC5d563A36AE78145C45a50134d48A1215220f80a",
+  conditionalTokens: "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
+  usdc: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+} as const;
+
+export const CHAIN_ID = 137;
+
+/** Row from the Turbo pipeline's order_fills sink */
+export type OrderFillRow = {
+  id: string;
+  block_number: number;
+  log_index: number;
+  transaction_hash: string;
+  block_timestamp: string;
+  maker: string;
+  taker: string;
+  maker_asset_id: string;
+  taker_asset_id: string;
+  maker_amount: number;
+  taker_amount: number;
+  fee: number;
+};
+
+/** Position tracked in collections */
+export type Position = {
+  id: string; // tokenId
+  tokenId: string;
+  conditionId: string;
+  side: "YES" | "NO";
+  size: number;
+  avgPrice: number;
+  status: "open" | "redeemed";
+};
+
+/** Trade record in collections */
+export type Trade = {
+  id: string;
+  tokenId: string;
+  side: "BUY" | "SELL";
+  amount: number;
+  price: number;
+  whalePrice: number;
+  slippage: number;
+  orderId?: string;
+  eventTxHash: string;
+  timestamp: string;
+};
+
+/** Gamma API market info needed for trading */
+export type MarketInfo = {
+  tokenId: string;
+  conditionId: string;
+  question: string;
+  tickSize: string;
+  negRisk: boolean;
+  enableOrderBook: boolean;
+  closed: boolean;
+  feeRateBps: number;
+  outcomePrices: [number, number];
+  clobTokenIds: [string, string];
+};
+

--- a/compose/copy-trader/src/tasks/copy_trade.ts
+++ b/compose/copy-trader/src/tasks/copy_trade.ts
@@ -1,0 +1,245 @@
+/**
+ * copy_trade — HTTP-triggered by Turbo pipeline webhook
+ *
+ * Receives a decoded OrderFilled event row from the pipeline.
+ * Determines buy/sell side, looks up market via Gamma, places CLOB order.
+ */
+import type { TaskContext } from "compose";
+import { privateKeyToAccount } from "viem/accounts";
+import { executeTrade } from "../lib/clob";
+import { lookupMarketByTokenId } from "../lib/gamma";
+import type { OrderFillRow, Position, Trade } from "../lib/types";
+
+export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
+  console.log("[copy_trade] invoked with params:", JSON.stringify(params));
+  if (!params) {
+    return { status: "NO_PARAMS" };
+  }
+
+  const row = params as unknown as OrderFillRow;
+
+  // Build watched wallet set from env (comma-separated)
+  const watchedWallets = new Set(
+    (ctx.env.WATCHED_WALLETS || "")
+      .split(",")
+      .map((w: string) => w.trim().toLowerCase())
+      .filter(Boolean)
+  );
+
+  // Parse the fill to determine side and token
+  const { side, tokenId, whalePrice } = parseFill(row, watchedWallets);
+  console.log(`[copy_trade] parsed: side=${side} tokenId=${tokenId.slice(0,15)}... price=${whalePrice}`);
+  if (!tokenId) {
+    return { status: "SKIP_NO_TOKEN" };
+  }
+
+  const tradeAmount = parseFloat(ctx.env.TRADE_AMOUNT_USD || "50");
+
+  // Resolve collections once (ctx.collection returns a Promise)
+  const positionsCollection = await ctx.collection<Position>("positions");
+  const tradesCollection = await ctx.collection<Trade>("trades");
+
+  // Budget check: read USDC.e balance on-chain (source of truth). If we don't
+  // have enough for the $1 minimum notional, skip. This avoids the local
+  // budget counter drifting out of sync with the real wallet.
+  if (side === "BUY") {
+    const pk = ctx.env.PRIVATE_KEY as `0x${string}`;
+    const address = privateKeyToAccount(
+      pk.startsWith("0x") ? pk : (`0x${pk}` as `0x${string}`)
+    ).address;
+    const balResp = (await ctx.fetch(
+      "https://polygon-bor-rpc.publicnode.com",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "eth_call",
+          params: [
+            {
+              to: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+              data: "0x70a08231000000000000000000000000" + address.slice(2).toLowerCase(),
+            },
+            "latest",
+          ],
+          id: 1,
+        }),
+      }
+    )) as { result?: string };
+    const usdcBalance = balResp?.result ? Number(BigInt(balResp.result)) / 1e6 : 0;
+    if (usdcBalance < 1.1) {
+      console.log(`[copy_trade] BALANCE_LOW: $${usdcBalance.toFixed(2)} (need >=$1.10)`);
+      return { status: "BALANCE_LOW", balance: usdcBalance };
+    }
+  }
+
+  // Look up market via Gamma
+  const gammaHost = ctx.env.GAMMA_HOST || "https://gamma-api.polymarket.com";
+  const market = await lookupMarketByTokenId(ctx.fetch, gammaHost, tokenId);
+
+  if (!market) {
+    console.log(`[copy_trade] MARKET_NOT_FOUND token=${tokenId.slice(0,15)}...`);
+    return { status: "MARKET_NOT_FOUND", tokenId };
+  }
+
+  if (!market.enableOrderBook) {
+    console.log(`[copy_trade] MARKET_CLOSED: ${market.question}`);
+    return { status: "MARKET_CLOSED", market: market.question };
+  }
+
+  // For sells, check we actually hold the share on-chain via Polymarket's
+  // data API (source of truth — the local positions collection can drift).
+  let sellSize = 0;
+  if (side === "SELL") {
+    const pk = ctx.env.PRIVATE_KEY as `0x${string}`;
+    const address = privateKeyToAccount(
+      pk.startsWith("0x") ? pk : (`0x${pk}` as `0x${string}`)
+    ).address;
+
+    const positions = (await ctx.fetch(
+      `https://data-api.polymarket.com/positions?user=${address}&limit=100&sortBy=CURRENT&sortOrder=DESC`
+    )) as Array<{ asset: string; size: number }>;
+
+    const match = positions.find((p) => p.asset === tokenId);
+    if (!match || match.size <= 0) {
+      console.log(
+        `[copy_trade] NO_POSITION to sell for ${tokenId.slice(0, 15)}...`
+      );
+      return { status: "NO_POSITION" };
+    }
+    sellSize = match.size;
+    console.log(
+      `[copy_trade] have ${sellSize} shares on-chain for ${tokenId.slice(0, 15)}...`
+    );
+  }
+
+  // Execute CLOB trade via proxy
+  const result = await executeTrade(
+    ctx,
+    ctx.env.PRIVATE_KEY,
+    ctx.env.CLOB_HOST || "https://fly-polymarket-proxy.fly.dev",
+    tokenId,
+    side,
+    tradeAmount,
+    whalePrice,
+    market.tickSize,
+    market.negRisk,
+    market.feeRateBps,
+    sellSize
+  );
+
+  if (!result.success) {
+    console.log(`[copy_trade] TRADE_FAILED: ${side} ${market.question} — ${result.error}`);
+    return { status: "TRADE_FAILED", error: result.error, market: market.question };
+  }
+
+  console.log(`[copy_trade] TRADE_EXECUTED: ${side} ${market.question} — order ${result.orderId}`);
+
+  // Update positions
+  const existingPos = (await positionsCollection.findOne({
+    tokenId,
+  })) as Position | null;
+
+  if (side === "BUY") {
+    const shares = tradeAmount / whalePrice;
+    if (existingPos) {
+      const newSize = existingPos.size + shares;
+      const newAvg =
+        (existingPos.avgPrice * existingPos.size + whalePrice * shares) /
+        newSize;
+      await positionsCollection.setById(existingPos.id, {
+        ...existingPos,
+        size: newSize,
+        avgPrice: newAvg,
+      });
+    } else {
+      await positionsCollection.insertOne({
+        id: tokenId,
+        tokenId,
+        conditionId: market.conditionId,
+        side: market.clobTokenIds[0] === tokenId ? "YES" : "NO",
+        size: shares,
+        avgPrice: whalePrice,
+        status: "open",
+      });
+    }
+
+  } else {
+    // Sell: zero out position
+    if (existingPos) {
+      await positionsCollection.setById(existingPos.id, {
+        ...existingPos,
+        size: 0,
+      });
+    }
+  }
+
+  // Record trade
+  await tradesCollection.insertOne({
+    id: `${row.transaction_hash}-${tokenId}-${Date.now()}`,
+    tokenId,
+    side,
+    amount: tradeAmount,
+    price: whalePrice,
+    whalePrice,
+    slippage: 0,
+    orderId: result.orderId,
+    eventTxHash: row.transaction_hash,
+    timestamp: new Date().toISOString(),
+  });
+
+  return {
+    status: "TRADE_EXECUTED",
+    side,
+    market: market.question,
+    orderId: result.orderId,
+  };
+}
+
+/**
+ * Parse an OrderFilled webhook payload to determine trade direction.
+ *
+ * CTF Exchange OrderFilled:
+ *   maker gives makerAsset of makerAmountFilled
+ *   taker gives takerAsset of takerAmountFilled
+ *   asset_id "0" = USDC (collateral), anything else = CTF share token
+ *
+ * The side we care about (BUY vs SELL) is the action the WATCHED WALLET is taking.
+ * The pipeline filters to trades where maker OR taker is a watched wallet.
+ *
+ * Price = USDC amount / shares amount (always in [0,1] for valid fills).
+ */
+function parseFill(
+  row: OrderFillRow,
+  watchedWallets: Set<string>
+): { side: "BUY" | "SELL"; tokenId: string; whalePrice: number } {
+  const makerIsWhale = watchedWallets.has(row.maker.toLowerCase());
+  const takerIsWhale = watchedWallets.has(row.taker.toLowerCase());
+
+  // Figure out which side is USDC and which is shares
+  const makerIsUsdc = row.maker_asset_id === "0";
+  const takerIsUsdc = row.taker_asset_id === "0";
+
+  if (!makerIsUsdc && !takerIsUsdc) {
+    // Share-for-share swap, shouldn't happen in normal flow
+    return { side: "BUY", tokenId: "", whalePrice: 0 };
+  }
+
+  // Identify share token and its amount, plus the USDC amount
+  const shareTokenId = makerIsUsdc ? row.taker_asset_id : row.maker_asset_id;
+  const sharesAmount = makerIsUsdc ? row.taker_amount : row.maker_amount;
+  const usdcAmount = makerIsUsdc ? row.maker_amount : row.taker_amount;
+  const price = sharesAmount > 0 ? usdcAmount / sharesAmount : 0;
+
+  // Whoever gives USDC is buying shares. Determine if watched wallet is the buyer.
+  const usdcGiver = makerIsUsdc ? "maker" : "taker";
+  const whaleIsUsdcGiver =
+    (usdcGiver === "maker" && makerIsWhale) ||
+    (usdcGiver === "taker" && takerIsWhale);
+
+  return {
+    side: whaleIsUsdcGiver ? "BUY" : "SELL",
+    tokenId: shareTokenId,
+    whalePrice: price,
+  };
+}

--- a/compose/copy-trader/src/tasks/redeem.ts
+++ b/compose/copy-trader/src/tasks/redeem.ts
@@ -1,0 +1,98 @@
+/**
+ * redeem — cron task (every 5 min)
+ *
+ * Queries Polymarket's data API for our wallet's redeemable positions and
+ * calls redeemPositions() on-chain for each. Polymarket marks a position
+ * `redeemable: true` when its condition has resolved on-chain.
+ *
+ * This intentionally doesn't use the local `positions` collection — the data
+ * API is the source of truth and already knows the conditionId + outcomeIndex
+ * for every share we hold, including trades that happened before this task
+ * existed or that didn't get recorded locally.
+ */
+import type { TaskContext } from "compose";
+import { CONTRACTS } from "../lib/types";
+import { privateKeyToAccount } from "viem/accounts";
+
+const CONDITIONAL_TOKENS_ABI =
+  "redeemPositions(address,bytes32,bytes32,uint256[])";
+
+type DataApiPosition = {
+  asset: string;
+  conditionId: string;
+  title: string;
+  outcomeIndex: number;
+  size: number;
+  currentValue: number;
+  redeemable: boolean;
+  // Multi-outcome markets have outcomeCount > 2; binary markets have 2.
+  // For a binary market, indexSets are: outcome 0 → 1, outcome 1 → 2.
+};
+
+export async function main(ctx: TaskContext) {
+  const pk = ctx.env.PRIVATE_KEY as `0x${string}`;
+  const address = privateKeyToAccount(
+    pk.startsWith("0x") ? pk : (`0x${pk}` as `0x${string}`)
+  ).address;
+
+  // sizeThreshold=0 is required: Polymarket's default threshold is 1.0, which
+  // hides any position holding <1 share. Fills that land just under 1 share
+  // (e.g. 0.9985 when buying at $0.99 due to fee routing) would otherwise
+  // never surface here, and winning positions of that size would sit
+  // un-redeemed indefinitely.
+  const resp = (await ctx.fetch(
+    `https://data-api.polymarket.com/positions?user=${address}&limit=100&sortBy=CURRENT&sortOrder=DESC&sizeThreshold=0`
+  )) as DataApiPosition[];
+
+  const toRedeem = (resp ?? []).filter(
+    (p) => p.redeemable === true && p.size > 0
+  );
+
+  if (!toRedeem.length) {
+    console.log("[redeem] no redeemable positions");
+    return { redeemed: 0 };
+  }
+
+  console.log(`[redeem] ${toRedeem.length} redeemable positions`);
+
+  const wallet = await ctx.evm.wallet({
+    name: "copy-trader",
+    privateKey: pk,
+    sponsorGas: true,
+  });
+
+  const parentCollectionId =
+    "0x0000000000000000000000000000000000000000000000000000000000000000";
+  const results: Array<{ condition: string; tx?: string; error?: string }> = [];
+
+  // Dedupe: redeeming one conditionId burns both YES and NO shares we hold
+  const seenConditions = new Set<string>();
+
+  for (const pos of toRedeem) {
+    if (seenConditions.has(pos.conditionId)) continue;
+    seenConditions.add(pos.conditionId);
+
+    // Binary market: indexSet 1 = outcome 0 (YES), indexSet 2 = outcome 1 (NO).
+    // Passing both [1, 2] redeems whatever we hold in one call.
+    const indexSets = [1, 2];
+
+    try {
+      console.log(
+        `[redeem] redeeming condition ${pos.conditionId.slice(0, 12)}... (${pos.title.slice(0, 40)})`
+      );
+      const tx = await wallet.writeContract(
+        ctx.evm.chains.polygon,
+        CONTRACTS.conditionalTokens as `0x${string}`,
+        CONDITIONAL_TOKENS_ABI,
+        [CONTRACTS.usdc, parentCollectionId, pos.conditionId, indexSets]
+      );
+      console.log(`[redeem] redeemed: ${tx.hash}`);
+      results.push({ condition: pos.conditionId, tx: tx.hash });
+    } catch (err) {
+      console.log(`[redeem] error for ${pos.conditionId}: ${err}`);
+      results.push({ condition: pos.conditionId, error: String(err) });
+    }
+  }
+
+  return { redeemed: results.length, results };
+}

--- a/compose/copy-trader/src/tasks/setup_approvals.ts
+++ b/compose/copy-trader/src/tasks/setup_approvals.ts
@@ -1,0 +1,61 @@
+/**
+ * setup_approvals — HTTP-triggered, run once after funding the wallet
+ *
+ * Grants USDC + ConditionalTokens approvals to Polymarket's exchange contracts.
+ * Required once before the bot can trade. Uses Compose's sponsored gas, so
+ * the EOA doesn't need MATIC.
+ *
+ * Call: curl -X POST -H "Authorization: Bearer $COMPOSE_TOKEN" \
+ *   https://api.goldsky.com/api/admin/compose/v1/copy-trader/tasks/setup_approvals
+ */
+import type { TaskContext } from "compose";
+import { CONTRACTS } from "../lib/types";
+
+const MAX_UINT256 =
+  115792089237316195423570985008687907853269984665640564039457584007913129639935n;
+
+const ERC20_APPROVE_ABI = "approve(address,uint256)";
+const ERC1155_SET_APPROVAL_ABI = "setApprovalForAll(address,bool)";
+
+export async function main(ctx: TaskContext) {
+  const wallet = await ctx.evm.wallet({
+    name: "copy-trader",
+    privateKey: ctx.env.PRIVATE_KEY as `0x${string}`,
+    sponsorGas: true,
+  });
+
+  const exchanges = [
+    { name: "CTF Exchange", address: CONTRACTS.ctfExchange },
+    { name: "NegRisk Exchange", address: CONTRACTS.negRiskExchange },
+  ];
+
+  const results: Array<{ name: string; type: string; tx: string }> = [];
+
+  // USDC.e (ERC-20) approvals — let each exchange spend our USDC
+  for (const ex of exchanges) {
+    console.log(`[setup_approvals] Approving USDC for ${ex.name}`);
+    const tx = await wallet.writeContract(
+      ctx.evm.chains.polygon,
+      CONTRACTS.usdc as `0x${string}`,
+      ERC20_APPROVE_ABI,
+      [ex.address, MAX_UINT256]
+    );
+    console.log(`[setup_approvals] USDC approved for ${ex.name}: ${tx.hash}`);
+    results.push({ name: ex.name, type: "USDC", tx: tx.hash });
+  }
+
+  // ConditionalTokens (ERC-1155) approvals — let each exchange move our share tokens
+  for (const ex of exchanges) {
+    console.log(`[setup_approvals] Approving ConditionalTokens for ${ex.name}`);
+    const tx = await wallet.writeContract(
+      ctx.evm.chains.polygon,
+      CONTRACTS.conditionalTokens as `0x${string}`,
+      ERC1155_SET_APPROVAL_ABI,
+      [ex.address, true]
+    );
+    console.log(`[setup_approvals] ConditionalTokens approved for ${ex.name}: ${tx.hash}`);
+    results.push({ name: ex.name, type: "CTF", tx: tx.hash });
+  }
+
+  return { success: true, wallet: wallet.address, approvals: results };
+}

--- a/compose/copy-trader/tsconfig.json
+++ b/compose/copy-trader/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "dom"],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "compose": [".compose/types.d.ts"]
+    }
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a Polymarket copy-trading template under `compose/copy-trader/`, alongside the existing VRF and bitcoin-oracle examples.

A Turbo pipeline decodes CTF Exchange `OrderFilled` events, filters to a configurable set of wallets, and webhooks each fill into a Compose app that signs + submits the mirrored order to the Polymarket CLOB via a Fly.io geo-unblock proxy. Winning shares auto-redeem every 5 minutes via cron.

## User journey

1. `npm install`
2. Set `WATCHED_WALLETS` in `compose.yaml` and the pipeline YAML
3. `goldsky compose secret set PRIVATE_KEY`
4. Create `COMPOSE_WEBHOOK_AUTH` (one-time per project)
5. `goldsky compose deploy` + `goldsky turbo apply`
6. Fund the EOA with USDC.e
7. Run `setup_approvals` once

## Compose features demonstrated

- Turbo → Compose webhook pattern (new to these examples)
- Cron triggers
- `ctx.fetch` for all outbound HTTP
- Sponsored-gas wallets via `ctx.evm.wallet`
- `ctx.collection` for persistent state

## Source

Template-ized from the live `goldsky-io/copy-trader` app. Dropped the `status` HTTP task (demo-only), the process docs (`docs/plans`, `docs/brainstorms`, `docs/solutions`), the `CLAUDE.md`, the wallet-finding methodology, and the stale `.env.example`.

## Test plan

- [x] `npm install` succeeds
- [x] `goldsky compose start` bundles all three tasks without errors
- [ ] Deploy to a fresh project end-to-end to confirm the six-step setup works