### PR TITLE
Remove logEvent calls from VRF example

### DIFF
--- a/compose/VRF/src/tasks/fulfill-randomness.ts
+++ b/compose/VRF/src/tasks/fulfill-randomness.ts
@@ -16,7 +16,7 @@ const CONTRACT_ADDRESS = "0xE05Ceb3E269029E3bab46E35515e8987060D1027";
  * Fetches verifiable randomness from drand and calls the target contract
  */
 export async function main(context: TaskContext, event?: OnchainEvent) {
-  const { fetch, evm, logEvent } = context;
+  const { fetch, evm } = context;
 
   // Parse request ID from event topics
   const requestId = event?.topics[1] ? BigInt(event.topics[1]) : 0n;
@@ -24,11 +24,7 @@ export async function main(context: TaskContext, event?: OnchainEvent) {
   // Fetch randomness from drand
   const drandResponse = await fetchLatestRandomness(fetch);
 
-  await logEvent({
-    code: "DRAND_FETCHED",
-    message: `Fetched drand round ${drandResponse.round}`,
-    data: JSON.stringify({ round: drandResponse.round }),
-  });
+  console.log(`fetched drand round ${drandResponse.round}`);
 
   // Get wallet and instantiate typed contract (generated from src/contracts/RandomnessConsumer.json)
   const wallet = await evm.wallet({
@@ -53,14 +49,7 @@ export async function main(context: TaskContext, event?: OnchainEvent) {
     signatureBytes
   );
 
-  await logEvent({
-    code: "RANDOMNESS_FULFILLED",
-    message: `Fulfilled request ${requestId} in tx ${hash}`,
-    data: JSON.stringify({
-      requestId: requestId.toString(),
-      txHash: hash,
-    }),
-  });
+  console.log(`fulfilled request ${requestId} in tx ${hash}`);
 
   return {
     success: true,


### PR DESCRIPTION
## Summary
- Replace `logEvent` calls with `console.log` in `compose/VRF/src/tasks/fulfill-randomness.ts`
- `logEvent` is being removed from the Compose context API (matches docs scrub in goldsky-io/docs#360)

## Test plan
- [ ] Redeploy VRF example and confirm task runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)