### PR TITLE
nav-oracle: address ce:review follow-ups (FOU-773)

### DIFF
--- a/compose/nav-oracle/README.md
+++ b/compose/nav-oracle/README.md
@@ -32,9 +32,9 @@ The deployed contract is [`AggregatorV3Interface`](https://docs.chain.link/data-
 - **Multi-chain publish** — one task writes to two chains in a single run, using `Promise.allSettled` so one chain's failure doesn't block the other
 - **Operator ripcord** — a kill-switch baked into the data source that lets an operator halt publishing without touching the task
 - **Structured on-chain state** — `(cash, tbills, repo, totalNav, asOf)` instead of a bare scalar
-- **`AggregatorV3Interface` compatibility** — drop-in for any existing Chainlink consumer
+- **`AggregatorV3Interface` compatibility** — drop-in for any existing Chainlink consumer (note: `updatedAt` reflects the on-chain write time; `startedAt` reflects the custodian's `asOf` valuation timestamp)
 - **Gas-sponsored wallet** — the publisher wallet never needs to hold ETH; `sponsorGas: true` is set on `evm.wallet()`
-- **Cron triggers, managed wallet, typed contract classes** — shared with the other compose examples
+- **Cron triggers, managed wallet, raw `wallet.writeContract`** — shared with the other compose examples. Uses a string ABI signature directly rather than `evm.contracts.X` codegen, since this app ships a hand-written ABI for one function.
 
 ## Quick Start
 
@@ -55,6 +55,8 @@ Save that address — it's the wallet that will sign `updateNav` calls, and it's
 ### 2. Deploy `ReserveAggregator` to both chains
 
 Install [Foundry](https://book.getfoundry.sh/getting-started/installation) if you haven't already.
+
+> **Use a throwaway deployer key.** `--private-key` puts the key in shell history and process listings. Use a fresh key with just enough gas to deploy — the contract has no further use for the deployer once it's live, so there's no reason to expose a key that holds anything else. For production deploys, prefer Foundry's `--account` keystore flag instead.
 
 ```bash
 # Base Sepolia
@@ -127,7 +129,14 @@ If your custodian API returns `"ripcord": true`, the task logs `Ripcord engaged 
 
 ### Add or swap chains
 
-`src/tasks/nav-oracle.ts` currently targets `evm.chains.baseSepolia` and `evm.chains.arbitrumSepolia`. Add another `new evm.contracts.ReserveAggregator(...)` in the `Promise.allSettled` block to publish to a third chain.
+`src/tasks/nav-oracle.ts` currently targets `evm.chains.baseSepolia` and `evm.chains.arbitrumSepolia`. To publish to a third chain, add another address constant at the top of the file and another `wallet.writeContract` entry inside the `Promise.allSettled` block:
+
+```ts
+const OPTIMISM_SEPOLIA_AGGREGATOR = "0x...";
+
+// inside Promise.allSettled([...])
+wallet.writeContract(evm.chains.optimismSepolia, OPTIMISM_SEPOLIA_AGGREGATOR, signature, args),
+```
 
 ### Change publish cadence
 
@@ -152,8 +161,11 @@ nav-oracle/
 ## Notes
 
 - `ReserveAggregator.getRoundData(_roundId)` only returns data for the latest round — this demo contract does not store history. For a production feed you'd add a round-indexed mapping.
-- The contract is single-operator by design: the publisher address is fixed in the constructor and only it can call `updateNav`. Rotate with `setPublisher(newAddress)`.
-- There's no automated test suite for the Solidity. The contract is ~120 lines and intentionally unaudited — do not use it in production without a proper review.
+- The contract is single-operator by design: the publisher address is fixed in the constructor and only it can call `updateNav`. Rotate with `setPublisher(newAddress)` — both the constructor and `setPublisher` reject `address(0)` to prevent accidental bricking.
+- The on-chain `updatedAt` returned from `latestRoundData()` is the block timestamp of the most recent write, matching Chainlink staleness conventions. `startedAt` returns the custodian's `asOf` valuation time. If your consumer treats these the same, point at `updatedAt`.
+- The pre-deployed demo addresses linked above run the original (PR #17) version of the contract; the zero-address guards and `updatedAt = block.timestamp` change shipped here apply to fresh deploys you make from this source.
+- The Solidity has no automated test suite. The contract is ~130 lines and intentionally unaudited — do not use it in production without a proper review.
+- `src/lib/scaling.ts` has a small Node test suite. Run with `npx tsx --test src/lib/scaling.test.ts` from this directory.
 
 ## Resources
 

--- a/compose/nav-oracle/contracts/ReserveAggregator.sol
+++ b/compose/nav-oracle/contracts/ReserveAggregator.sol
@@ -20,7 +20,8 @@ contract ReserveAggregator {
         uint256 tbills;
         uint256 repo;
         uint256 totalNav;
-        uint64  asOf;
+        uint64  asOf;       // custodian-side valuation timestamp
+        uint64  updatedAt;  // block.timestamp at on-chain write
         uint80  roundId;
     }
 
@@ -55,12 +56,15 @@ contract ReserveAggregator {
     error OnlyPublisher();
     error NoDataYet();
     error NoHistoricalData(uint80 requestedRound, uint80 latestRound);
+    error ZeroAddress();
+    error NavOverflowsInt256(uint256 totalNav);
 
     // ============ Constructor ============
 
     /// @param _publisher The Compose managed wallet authorized to call updateNav.
     /// @param _description A short label for this feed (e.g. "Example RWA Fund I NAV / USD").
     constructor(address _publisher, string memory _description) {
+        if (_publisher == address(0)) revert ZeroAddress();
         publisher = _publisher;
         feedDescription = _description;
     }
@@ -83,16 +87,20 @@ contract ReserveAggregator {
         uint64  asOf
     ) external {
         if (msg.sender != publisher) revert OnlyPublisher();
+        // AggregatorV3Interface returns int256; guard so latestRoundData
+        // can never expose a wrapped negative answer for absurd uint values.
+        if (totalNav > uint256(type(int256).max)) revert NavOverflowsInt256(totalNav);
 
         uint80 nextRound = _latest.roundId + 1;
 
         _latest = NavBundle({
-            cash:     cash,
-            tbills:   tbills,
-            repo:     repo,
-            totalNav: totalNav,
-            asOf:     asOf,
-            roundId:  nextRound
+            cash:      cash,
+            tbills:    tbills,
+            repo:      repo,
+            totalNav:  totalNav,
+            asOf:      asOf,
+            updatedAt: uint64(block.timestamp),
+            roundId:   nextRound
         });
 
         emit NavUpdated(nextRound, totalNav, cash, tbills, repo, asOf);
@@ -104,6 +112,10 @@ contract ReserveAggregator {
      */
     function setPublisher(address newPublisher) external {
         if (msg.sender != publisher) revert OnlyPublisher();
+        // Rotating to address(0) would brick the contract (msg.sender can never
+        // equal address(0)), so reject explicitly. There is no recovery path
+        // from a misset publisher otherwise.
+        if (newPublisher == address(0)) revert ZeroAddress();
         emit PublisherRotated(publisher, newPublisher);
         publisher = newPublisher;
     }
@@ -138,8 +150,8 @@ contract ReserveAggregator {
         return (
             _latest.roundId,
             int256(_latest.totalNav),
-            uint256(_latest.asOf),
-            uint256(_latest.asOf),
+            uint256(_latest.asOf),       // startedAt = custodian valuation timestamp
+            uint256(_latest.updatedAt),  // updatedAt = on-chain write block timestamp (matches Chainlink staleness semantics)
             _latest.roundId
         );
     }
@@ -167,7 +179,7 @@ contract ReserveAggregator {
             _latest.roundId,
             int256(_latest.totalNav),
             uint256(_latest.asOf),
-            uint256(_latest.asOf),
+            uint256(_latest.updatedAt),
             _latest.roundId
         );
     }

--- a/compose/nav-oracle/src/lib/scaling.ts
+++ b/compose/nav-oracle/src/lib/scaling.ts
@@ -1,9 +1,20 @@
 /**
- * Convert a human-readable USD number (e.g. 42_500_000.50) to a
- * 18-decimal fixed-point bigint (e.g. 42500000500000000000000000n).
+ * Convert a non-negative USD number (e.g. 42_500_000.50) to a 18-decimal
+ * fixed-point bigint (e.g. 42500000500000000000000000n).
  *
- * Uses string math to avoid binary-float precision loss that would
- * otherwise corrupt values like 0.1 + 0.2.
+ * Precision caveat: the input is already a JS double, so any precision
+ * already lost in the float representation (e.g. 0.1 + 0.2 holds the value
+ * 0.30000000000000004) survives into the output. Using toFixed(18) +
+ * string concatenation avoids *additional* float ops in the conversion
+ * path; it does not recover bits that were never in the input. For amounts
+ * that need exact decimal precision, accept a decimal string upstream and
+ * parse it with a fixed-point library instead of taking a number here.
+ *
+ * Bounds:
+ *   - |value| > Number.MAX_SAFE_INTEGER (~9e15) is rejected: integer bits
+ *     are already lost in the double, and at >= 1e21 V8's toFixed switches
+ *     to scientific notation, which would produce a malformed bigint string.
+ *   - Negative and non-finite values are rejected.
  */
 export function toScaled18(value: number): bigint {
   if (!Number.isFinite(value)) {
@@ -11,6 +22,12 @@ export function toScaled18(value: number): bigint {
   }
   if (value < 0) {
     throw new Error(`toScaled18: negative value ${value}`);
+  }
+  if (value > Number.MAX_SAFE_INTEGER) {
+    throw new Error(
+      `toScaled18: value ${value} exceeds Number.MAX_SAFE_INTEGER (9.007e15). ` +
+        `Pass a string and parse with a fixed-point library to preserve precision.`
+    );
   }
   const fixed = value.toFixed(18);
   const [whole, frac = ""] = fixed.split(".");

--- a/compose/nav-oracle/src/tasks/nav-oracle.ts
+++ b/compose/nav-oracle/src/tasks/nav-oracle.ts
@@ -8,6 +8,10 @@ import { toScaled18 } from "../lib/scaling";
  * Mock custodian endpoint. The default points at this repo's static
  * `mock-custodian.json`, served via GitHub raw. Swap for your own custodian
  * API when you're ready — the response JSON must match CustodianResponse below.
+ *
+ * Production: prefer an HTTPS endpoint you control. The fetched bundle is
+ * written verbatim to on-chain state, so a MITM-vulnerable transport is a
+ * data-integrity risk.
  */
 const CUSTODIAN_URL =
   "https://raw.githubusercontent.com/goldsky-io/documentation-examples/main/compose/nav-oracle/mock-custodian.json";
@@ -19,8 +23,8 @@ const CUSTODIAN_URL =
  * create nav-oracle-publisher --env cloud` and deployed the contract via
  * `forge create`.
  */
-const BASE_SEPOLIA_AGGREGATOR     = "0x8099A30Ac752f86C77A0e0210085a908ba6d02fE";
-const ARBITRUM_SEPOLIA_AGGREGATOR = "0x02D9Df62B7AED15739D638B92BAcEA2ce4Cb3d70";
+const BASE_SEPOLIA_AGGREGATOR     = "0x0000000000000000000000000000000000000000";
+const ARBITRUM_SEPOLIA_AGGREGATOR = "0x0000000000000000000000000000000000000000";
 
 // ─── Internals ────────────────────────────────────────────────────────────
 
@@ -34,6 +38,37 @@ interface CustodianResponse {
   repo: number;      // USD
   totalNav: number;  // USD
   ripcord: boolean;  // operator kill-switch
+}
+
+/**
+ * `fetch<T>` is a TypeScript cast — there is no runtime schema validation.
+ * A real custodian API can return anything the network lets through. Validate
+ * before scaling so misshapen payloads surface as field-level errors instead
+ * of cryptic `non-finite value undefined` or `BigInt(NaN)` throws downstream.
+ */
+function validateBundle(bundle: unknown): asserts bundle is CustodianResponse {
+  if (typeof bundle !== "object" || bundle === null) {
+    throw new Error("Custodian response is not an object");
+  }
+  const b = bundle as Record<string, unknown>;
+  for (const field of ["cash", "tbills", "repo", "totalNav"] as const) {
+    if (typeof b[field] !== "number" || !Number.isFinite(b[field] as number)) {
+      throw new Error(`Custodian response field '${field}' is not a finite number (got ${JSON.stringify(b[field])})`);
+    }
+  }
+  if (typeof b.ripcord !== "boolean") {
+    throw new Error(`Custodian response field 'ripcord' is not a boolean (got ${JSON.stringify(b.ripcord)})`);
+  }
+  if (typeof b.asOf !== "string") {
+    throw new Error(`Custodian response field 'asOf' is not a string (got ${JSON.stringify(b.asOf)})`);
+  }
+  const ts = new Date(b.asOf).getTime();
+  if (!Number.isFinite(ts)) {
+    throw new Error(`Custodian response field 'asOf' is not a parseable ISO 8601 date (got '${b.asOf}')`);
+  }
+  if (typeof b.accountName !== "string") {
+    throw new Error(`Custodian response field 'accountName' is not a string`);
+  }
 }
 
 export async function main(context: TaskContext) {
@@ -72,6 +107,7 @@ export async function main(context: TaskContext) {
   if (!bundle) {
     throw new Error("Custodian fetch returned empty response");
   }
+  validateBundle(bundle);
 
   // Ripcord: the operator has flagged a problem upstream. Do not publish —
   // the next cron run will re-check. This is not an error; returning cleanly
@@ -84,6 +120,7 @@ export async function main(context: TaskContext) {
   }
 
   // Scale human USD → 18-decimal fixed-point, and ISO timestamp → unix seconds.
+  // validateBundle has already proven asOf parses, so the BigInt conversion is safe.
   const cash     = toScaled18(bundle.cash);
   const tbills   = toScaled18(bundle.tbills);
   const repo     = toScaled18(bundle.repo);
@@ -94,7 +131,10 @@ export async function main(context: TaskContext) {
   const args = [cash, tbills, repo, totalNav, asOf];
 
   // Publish to both chains independently. allSettled prevents one chain's
-  // failure from blocking the other; the next cron cycle reconciles.
+  // failure from blocking the other. Note: a partial failure leaves the
+  // failed chain one roundId behind; the next cycle will not back-fill the
+  // missed round, it just publishes the new one. Multi-chain consumers that
+  // compare roundId across chains for liveness will see the divergence.
   const results = await Promise.allSettled([
     wallet.writeContract(evm.chains.baseSepolia,      BASE_SEPOLIA_AGGREGATOR,     signature, args),
     wallet.writeContract(evm.chains.arbitrumSepolia, ARBITRUM_SEPOLIA_AGGREGATOR, signature, args),
@@ -102,10 +142,13 @@ export async function main(context: TaskContext) {
 
   const [baseResult, arbResult] = results;
 
-  const summarize = (r: PromiseSettledResult<{ hash: string }>) =>
-    r.status === "fulfilled"
-      ? { ok: true,  hash: r.value.hash }
-      : { ok: false, error: (r.reason as Error)?.message ?? String(r.reason) };
+  const summarize = (r: PromiseSettledResult<{ hash: string }>) => {
+    if (r.status === "fulfilled") {
+      return { ok: true, hash: r.value.hash } as const;
+    }
+    const error = r.reason instanceof Error ? r.reason.message : String(r.reason);
+    return { ok: false, error } as const;
+  };
 
   const baseOut = summarize(baseResult);
   const arbOut  = summarize(arbResult);
@@ -116,7 +159,6 @@ export async function main(context: TaskContext) {
   );
 
   // If both chains failed, surface as a task error so compose retries.
-  // Partial failures are tolerated; next cron cycle will catch up.
   if (!baseOut.ok && !arbOut.ok) {
     throw new Error(
       `Both chain writes failed. base: ${baseOut.error}; arb: ${arbOut.error}`

--- a/compose/nav-oracle/tests/scaling.test.ts
+++ b/compose/nav-oracle/tests/scaling.test.ts
@@ -1,0 +1,46 @@
+// Run from compose/nav-oracle/: npx tsx --test tests/scaling.test.ts
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { toScaled18 } from "../src/lib/scaling";
+
+test("scales whole USD to 18 decimals", () => {
+  assert.equal(toScaled18(1), 1_000_000_000_000_000_000n);
+  assert.equal(toScaled18(0), 0n);
+});
+
+test("scales fractional USD via toFixed(18) — float noise in the input survives", () => {
+  // 0.1 + 0.2 holds the double 0.30000000000000004; toFixed(18) emits
+  // "0.300000000000000044". The function does not (and cannot) recover bits
+  // that were never in the input. Asserting the actual behavior locks in the
+  // contract for callers.
+  assert.equal(toScaled18(0.1 + 0.2), 300_000_000_000_000_044n);
+  assert.equal(toScaled18(50_825_000), 50_825_000_000_000_000_000_000_000n);
+});
+
+test("scales values up to MAX_SAFE_INTEGER", () => {
+  // 9_007_199_254_740_991 is exactly representable in a double.
+  assert.equal(
+    toScaled18(Number.MAX_SAFE_INTEGER),
+    9_007_199_254_740_991_000_000_000_000_000_000n
+  );
+});
+
+test("rejects negative values", () => {
+  assert.throws(() => toScaled18(-1), /negative value/);
+});
+
+test("rejects non-finite values", () => {
+  assert.throws(() => toScaled18(NaN), /non-finite value/);
+  assert.throws(() => toScaled18(Infinity), /non-finite value/);
+  assert.throws(() => toScaled18(-Infinity), /non-finite value/);
+});
+
+test("rejects values above MAX_SAFE_INTEGER instead of silently corrupting them", () => {
+  // toFixed(18) emits scientific notation for values >= 1e21, which would
+  // produce an invalid bigint string. The guard fires first regardless.
+  assert.throws(() => toScaled18(1e21), /exceeds Number\.MAX_SAFE_INTEGER/);
+  assert.throws(
+    () => toScaled18(Number.MAX_SAFE_INTEGER + 2),
+    /exceeds Number\.MAX_SAFE_INTEGER/
+  );
+});


### PR DESCRIPTION
## Summary

Follow-up to #17 addressing the `ce:review` findings. Same nav-oracle example, no new files in `compose/nav-oracle/` other than the test file.

Linear: [FOU-773](https://linear.app/goldsky/issue/FOU-773)

## What changed

### Solidity (`ReserveAggregator.sol`)
- **Zero-address guards** on the constructor and `setPublisher`. Rotation to `address(0)` would permanently brick the contract (`msg.sender` can never equal `address(0)`), and there's no recovery path.
- **`int256` overflow guard** in `updateNav` — rejects `totalNav` larger than `int256` max so `latestRoundData()` can never return a wrapped negative answer.
- **`updatedAt` now reflects `block.timestamp`** of the on-chain write (Chainlink staleness convention). `startedAt` continues to reflect the custodian's `asOf` valuation timestamp. This adds a `uint64 updatedAt` field to `NavBundle`.

### Task (`src/tasks/nav-oracle.ts`)
- New `validateBundle()` helper between the fetch and the scaling/asOf calls. `fetch<T>` is a TypeScript cast, not runtime validation — `validateBundle` does explicit `typeof`/`Number.isFinite`/`Date.parse` checks per field so a misshapen custodian payload surfaces as `Custodian response field 'totalNav' is not a finite number` instead of `Cannot convert NaN to a BigInt` four lines later. Notably catches missing `ripcord` (which would silently disable the kill-switch) and unparseable `asOf` (which would otherwise hit `BigInt(NaN)` with no field-level diagnostic).
- **Reset `BASE_SEPOLIA_AGGREGATOR` / `ARBITRUM_SEPOLIA_AGGREGATOR` back to zero-address defaults** so the placeholder-skip guard actually fires on a fresh clone. The demo addresses now live in the README only.
- Replace `(r.reason as Error)?.message` with `instanceof Error` narrowing in `summarize`.
- Correct the partial-failure comment: a failed chain stays one round behind; the next cycle does not back-fill.

### Lib (`src/lib/scaling.ts`)
- **Reject `value > Number.MAX_SAFE_INTEGER`**. At `>= 1e21` V8's `toFixed` emits scientific notation (`'1e+21'`), which produces a malformed bigint string and a confusing `SyntaxError`. The new guard surfaces the problem with a clear, field-named error at the boundary.
- Tighten the docstring: float noise already in the input *does* survive (e.g. `0.1 + 0.2` → `300000000000000044n`). The "string math" approach only avoids additional float ops; it does not recover bits the input never had. For amounts that need exact decimal precision, take a string upstream.

### Tests (`tests/scaling.test.ts`)
- Six vectors using `node:test`: whole-USD scaling, fractional with the survived-float-noise contract, `MAX_SAFE_INTEGER`, and the negative/non-finite/oversized guards. Run from `compose/nav-oracle/`:
  ```bash
  npx tsx --test tests/scaling.test.ts
  ```

### README
- Drop the "typed contract classes" feature claim — this app uses raw `wallet.writeContract` with a string ABI signature. Add a note on `AggregatorV3Interface` semantics (`updatedAt` = block timestamp, `startedAt` = custodian `asOf`).
- Fix the **Add or swap chains** snippet: was `new evm.contracts.ReserveAggregator(...)` (a class that doesn't exist); now shows a real `wallet.writeContract(...)` entry.
- Add a **throwaway-deployer-key warning** before the `forge create` commands.
- Note that the linked demo addresses run the original (PR #17) contract; the new guards apply to fresh deploys.

## Findings closed

P0-1 (setPublisher zero-addr), P1-1 (asOf NaN crash), P1-2 (toScaled18 1e21 RangeError + docstring), P1-3 (placeholder defaults), P1-4 (README typed-class drift), P1-5 (no runtime validation), P2-1 (constructor zero-addr), P2-2 (updatedAt semantics), P2-3 (partial-failure comment), P2-4 (no toScaled18 tests), P3-1 (int256 overflow), P3-2 (private-key warning), P3-3 (summarize cast).

Not addressed (deferred as scope creep on a docs example): P2-5 (ABI signature drift detection — would need codegen-from-`.sol`, not just `.json`), P2-6 (writeContract timeout — needs SDK API I don't see), P3-4 (three-name canonicalization — pure rename), P3-5 (retry-config divergence comment).

## Testing

- `tsc --noEmit` — passes ✓
- `npx tsx --test tests/scaling.test.ts` — 6 pass, 0 fail ✓
- Not deployed live; the contract change requires a fresh `forge create` against the new bytecode for any consumer that wants the `updatedAt = block.timestamp` semantics.

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)