### PR TITLE
Update copy-trader for Polymarket V2 (cutover 2026-04-28)

### DIFF
--- a/compose/copy-trader/README.md
+++ b/compose/copy-trader/README.md
@@ -2,16 +2,18 @@
 
 A [Compose](https://docs.goldsky.com/compose/introduction) + [Turbo](https://docs.goldsky.com/turbo/introduction) example that mirrors Polymarket trades from any set of wallets you choose. When a watched wallet buys or sells, the bot places the same side on the CLOB with a $1 notional.
 
+Updated for [Polymarket V2](https://docs.polymarket.com/v2-migration) (cutover 2026-04-28): new V2 Exchange contracts, pUSD collateral, `@polymarket/clob-client-v2`.
+
 ## How It Works
 
 ```
 Polygon on-chain
        │
-       └─ CTF Exchange + NegRisk Exchange: OrderFilled events
+       └─ V2 CTF Exchange + V2 NegRisk Exchange: OrderFilled events
             │
             ▼
   ┌──────────────────────┐
-  │  Turbo Pipeline      │  decode fills, filter to watched wallets
+  │  Turbo Pipeline      │  decode V2 fills, filter to watched wallets
   │  (polymarket-ctf-    │  → webhook per fill
   │   events)            │
   └──────────┬───────────┘
@@ -20,9 +22,9 @@ Polygon on-chain
   ┌──────────────────────┐
   │  Compose App         │
   ├──────────────────────┤
-  │  copy_trade (http)   │  sign + POST order to Polymarket CLOB
+  │  copy_trade (http)   │  sign + POST V2 order to Polymarket CLOB
   │  redeem (cron 5m)    │  redeem winning shares on-chain
-  │  setup_approvals     │  one-time USDC + CTF approvals
+  │  setup_approvals     │  one-time approvals + USDC.e → pUSD wrap
   └──────────────────────┘
 ```
 
@@ -74,11 +76,11 @@ goldsky turbo apply pipeline/polymarket-ctf-events.yaml
 
 ### 6. Fund the wallet
 
-Send USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) on Polygon to your EOA. Compose sponsors gas, so no MATIC is required.
+Send USDC.e (`0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174`) on Polygon to your EOA. Compose sponsors gas, so no MATIC is required. `setup_approvals` will wrap the USDC.e into pUSD before trading.
 
-### 7. Grant approvals
+### 7. Grant approvals + wrap collateral
 
-One-time ERC-20 + ERC-1155 approvals to the CTF Exchange and NegRisk Exchange. Triggers four sponsored on-chain transactions:
+One-time setup that approves the Collateral Onramp and both V2 Exchanges, then wraps your USDC.e balance into pUSD. Triggers a handful of sponsored on-chain transactions:
 
 ```bash
 curl -X POST -H "Authorization: Bearer $COMPOSE_TOKEN" \
@@ -86,6 +88,8 @@ curl -X POST -H "Authorization: Bearer $COMPOSE_TOKEN" \
 ```
 
 The bot starts trading as soon as a watched wallet's next fill hits the pipeline.
+
+To top up later: send more USDC.e to the EOA, then call `setup_approvals` again. It's idempotent — re-runs just re-emit the (already-set) approvals and wrap whatever USDC.e the wallet currently holds.
 
 ## Project Structure
 
@@ -98,13 +102,13 @@ copy-trader/
 │   └── polymarket-ctf-events.yaml         # Turbo pipeline → webhook sink
 └── src/
     ├── lib/
-    │   ├── clob.ts                        # Polymarket CLOB client (ctx.fetch based)
+    │   ├── clob.ts                        # V2 CLOB client (ctx.fetch based)
     │   ├── gamma.ts                       # Market metadata lookups
     │   └── types.ts                       # Contract addresses + shared types
     └── tasks/
         ├── copy_trade.ts                  # HTTP: receive fill → mirror trade
         ├── redeem.ts                      # Cron: redeem winning shares
-        └── setup_approvals.ts             # HTTP: one-time approvals
+        └── setup_approvals.ts             # HTTP: approvals + USDC.e → pUSD wrap
 ```
 
 ## Compose Features Demonstrated
@@ -112,7 +116,7 @@ copy-trader/
 - **Turbo → Compose webhook** — a Turbo pipeline sinks decoded events to a Compose HTTP task
 - **Cron triggers** — `redeem` runs every 5 minutes
 - **`ctx.fetch`** — all outbound HTTP (Polymarket CLOB + Gamma + data API) goes through Compose's host-mediated fetch
-- **`ctx.evm.wallet` with sponsored gas** — on-chain calls (approvals, redemptions) use a Compose-sponsored wallet
+- **`ctx.evm.wallet` with sponsored gas** — on-chain calls (approvals, wrap, redemptions) use a Compose-sponsored wallet
 - **`ctx.collection`** — `positions` and `trades` collections for persistent state
 - **Secrets** — wallet private key stored via `goldsky compose secret set`
 
@@ -133,11 +137,24 @@ TRADE_AMOUNT_USD: "10"
 ## Notes
 
 - The bot signs directly as the EOA. No Polymarket proxy wallet, no UI onboarding needed — just fund the EOA address with USDC.e.
-- `copy_trade` reads on-chain USDC balance before every BUY and skips if it would breach the $1.10 minimum. Local balance tracking isn't used — the chain is the source of truth.
-- `setup_approvals` is idempotent. Re-run it any time (e.g. after rotating keys) and it just re-emits the same `approve` / `setApprovalForAll` transactions.
+- `copy_trade` reads on-chain pUSD balance before every BUY and skips if it would breach the $1.10 minimum. Local balance tracking isn't used — the chain is the source of truth.
+- `setup_approvals` is idempotent. Re-run it after every USDC.e top-up to wrap fresh collateral; the approvals are max-allowance so re-approving is a cheap no-op.
+- `redeem` only handles standard (non-NegRisk) markets. NegRisk redemption goes through the NegRiskAdapter contract — out of scope for this example.
+
+## V2 contracts on Polygon
+
+| Contract | Address |
+|----------|---------|
+| CTF Exchange V2 | `0xE111180000d2663C0091e4f400237545B87B996B` |
+| NegRisk Exchange V2 | `0xe2222d279d744050d28e00520010520000310F59` |
+| Conditional Tokens (unchanged) | `0x4D97DCd97eC945f40cF65F87097ACe5EA0476045` |
+| Collateral Onramp | `0x93070a847efEf7F70739046A929D47a521F5B8ee` |
+| pUSD | `0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB` |
+| USDC.e | `0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174` |
 
 ## Resources
 
 - [Compose Documentation](https://docs.goldsky.com/compose/introduction)
 - [Turbo Documentation](https://docs.goldsky.com/turbo/introduction)
+- [Polymarket V2 migration](https://docs.polymarket.com/v2-migration)
 - [Polymarket CLOB API](https://docs.polymarket.com/)

--- a/compose/copy-trader/package-lock.json
+++ b/compose/copy-trader/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@ethersproject/wallet": "^5.8.0",
-        "@polymarket/clob-client": "^5.1.3",
-        "viem": "^2.43.2"
+        "@polymarket/clob-client-v2": "^1.0.2",
+        "viem": "^2.46.3"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -370,6 +370,65 @@
         "@ethersproject/logger": "^5.8.0"
       }
     },
+    "node_modules/@ethersproject/providers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.8.0.tgz",
+      "integrity": "sha512-3Il3oTzEx3o6kzcg9ZzbE+oCZYyY+3Zh83sKkn4s1DZfTUjIegHnN2Cm0kbn9YFy45FDVcuCLLONhU7ny0SsCw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abstract-provider": "^5.8.0",
+        "@ethersproject/abstract-signer": "^5.8.0",
+        "@ethersproject/address": "^5.8.0",
+        "@ethersproject/base64": "^5.8.0",
+        "@ethersproject/basex": "^5.8.0",
+        "@ethersproject/bignumber": "^5.8.0",
+        "@ethersproject/bytes": "^5.8.0",
+        "@ethersproject/constants": "^5.8.0",
+        "@ethersproject/hash": "^5.8.0",
+        "@ethersproject/logger": "^5.8.0",
+        "@ethersproject/networks": "^5.8.0",
+        "@ethersproject/properties": "^5.8.0",
+        "@ethersproject/random": "^5.8.0",
+        "@ethersproject/rlp": "^5.8.0",
+        "@ethersproject/sha2": "^5.8.0",
+        "@ethersproject/strings": "^5.8.0",
+        "@ethersproject/transactions": "^5.8.0",
+        "@ethersproject/web": "^5.8.0",
+        "bech32": "1.1.4",
+        "ws": "8.18.0"
+      }
+    },
+    "node_modules/@ethersproject/providers/node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ethersproject/random": {
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.8.0.tgz",
@@ -621,29 +680,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@polymarket/builder-signing-sdk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@polymarket/builder-signing-sdk/-/builder-signing-sdk-1.0.0.tgz",
-      "integrity": "sha512-LNHc8Ox+2ITM6+VIEH5LH3SVh9ScE2mOUAJI789YfyNqhF4n1cNulk35Hb6IZfy1xtNfcEfNotanPLa/U8dCaw==",
+    "node_modules/@polymarket/clob-client-v2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@polymarket/clob-client-v2/-/clob-client-v2-1.0.2.tgz",
+      "integrity": "sha512-lC80Esug6s6y3uV8D5HnkxoXVZUnATjyP6PcK2IXO740iGDuLlp9Dvvkx3+VVygHahN+M3NY7JiYiTQkDfWoeQ==",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.12.2"
+        "@ethersproject/providers": "^5.8.0",
+        "@ethersproject/wallet": "^5.8.0",
+        "axios": "^1.0.0",
+        "browser-or-node": "^3.0.0",
+        "tslib": "^2.8.1",
+        "viem": "^2.46.3"
       }
     },
-    "node_modules/@polymarket/clob-client": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/@polymarket/clob-client/-/clob-client-5.8.1.tgz",
-      "integrity": "sha512-beKC4KPc9dYyFV9wFhKiGoA16q5xWz4PjkYcnEs3BzpsOKjGQGRlZQ7KQD4HQKUd3HC5RLQT0lqWHrFyaI+2fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@polymarket/builder-signing-sdk": "^1.0.0",
-        "axios": "^1.0.0",
-        "browser-or-node": "^2.1.1",
-        "viem": "^2.46.3"
-      },
-      "engines": {
-        "node": ">=20.10"
-      }
+    "node_modules/@polymarket/clob-client-v2/node_modules/browser-or-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-3.0.0.tgz",
+      "integrity": "sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==",
+      "license": "MIT"
     },
     "node_modules/@scure/base": {
       "version": "1.2.6",
@@ -725,6 +780,12 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==",
+      "license": "MIT"
+    },
     "node_modules/bn.js": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
@@ -735,12 +796,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
-    },
-    "node_modules/browser-or-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.1.1.tgz",
-      "integrity": "sha512-8CVjaLJGuSKMVTxJ2DpBl5XnlNDiT4cQFeuCJJrvJmts9YrTZDizTX7PjC2s6W4x+MBGZeEY6dGMrF04/6Hgqg==",
       "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1130,6 +1185,12 @@
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/viem": {
       "version": "2.48.1",

--- a/compose/copy-trader/package.json
+++ b/compose/copy-trader/package.json
@@ -5,7 +5,7 @@
   "description": "Polymarket copy-trading example for Goldsky Compose + Turbo",
   "dependencies": {
     "@ethersproject/wallet": "^5.8.0",
-    "@polymarket/clob-client": "^5.1.3",
-    "viem": "^2.43.2"
+    "@polymarket/clob-client-v2": "^1.0.2",
+    "viem": "^2.46.3"
   }
 }

--- a/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
+++ b/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
@@ -1,6 +1,6 @@
 name: polymarket-ctf-events
 resource_size: s
-description: "Index Polymarket CTF Exchange fills for watched wallets → webhook to Compose"
+description: "Index Polymarket V2 CTF Exchange fills for watched wallets → webhook to Compose"
 
 sources:
   poly_logs:
@@ -8,10 +8,11 @@ sources:
     dataset_name: matic.raw_logs
     version: 1.0.0
     start_at: latest
+    # V2 CTF Exchange + V2 NegRisk CTF Exchange (cutover 2026-04-28).
     filter: >-
       address IN (
-        '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e',
-        '0xc5d563a36ae78145c45a50134d48a1215220f80a'
+        '0xe111180000d2663c0091e4f400237545b87b996b',
+        '0xe2222d279d744050d28e00520010520000310f59'
       )
 
 transforms:
@@ -26,7 +27,7 @@ transforms:
         transaction_hash,
         to_timestamp(block_timestamp) AS block_timestamp,
         evm_log_decode(
-          '[{"anonymous":false,"inputs":[{"indexed":true,"name":"orderHash","type":"bytes32"},{"indexed":true,"name":"maker","type":"address"},{"indexed":true,"name":"taker","type":"address"},{"indexed":false,"name":"makerAssetId","type":"uint256"},{"indexed":false,"name":"takerAssetId","type":"uint256"},{"indexed":false,"name":"makerAmountFilled","type":"uint256"},{"indexed":false,"name":"takerAmountFilled","type":"uint256"},{"indexed":false,"name":"fee","type":"uint256"}],"name":"OrderFilled","type":"event"}]',
+          '[{"anonymous":false,"inputs":[{"indexed":true,"name":"orderHash","type":"bytes32"},{"indexed":true,"name":"maker","type":"address"},{"indexed":true,"name":"taker","type":"address"},{"indexed":false,"name":"side","type":"uint8"},{"indexed":false,"name":"tokenId","type":"uint256"},{"indexed":false,"name":"makerAmountFilled","type":"uint256"},{"indexed":false,"name":"takerAmountFilled","type":"uint256"},{"indexed":false,"name":"fee","type":"uint256"},{"indexed":false,"name":"builder","type":"bytes32"},{"indexed":false,"name":"metadata","type":"bytes32"}],"name":"OrderFilled","type":"event"}]',
           topics,
           `data`
         ) AS `decoded`
@@ -44,8 +45,8 @@ transforms:
         block_timestamp,
         LOWER(`decoded`.event_params[2]) AS maker,
         LOWER(`decoded`.event_params[3]) AS taker,
-        `decoded`.event_params[4] AS maker_asset_id,
-        `decoded`.event_params[5] AS taker_asset_id,
+        `decoded`.event_params[4] AS side,
+        `decoded`.event_params[5] AS token_id,
         CAST(`decoded`.event_params[6] AS DOUBLE) / 1e6 AS maker_amount,
         CAST(`decoded`.event_params[7] AS DOUBLE) / 1e6 AS taker_amount,
         CAST(`decoded`.event_params[8] AS DOUBLE) / 1e6 AS fee

--- a/compose/copy-trader/src/lib/clob.ts
+++ b/compose/copy-trader/src/lib/clob.ts
@@ -1,7 +1,7 @@
 /**
- * Minimal Polymarket CLOB client that uses ctx.fetch for all HTTP.
+ * Minimal Polymarket V2 CLOB client that uses ctx.fetch for all HTTP.
  *
- * The @polymarket/clob-client SDK uses axios, which fails under Compose's
+ * The @polymarket/clob-client-v2 SDK uses axios, which fails under Compose's
  * Deno runtime (no --allow-net on task binaries). We reuse the SDK's pure
  * signing utilities (no HTTP) and route every API call through ctx.fetch,
  * which bridges to the host process that has network permissions.
@@ -12,13 +12,20 @@
  */
 import type { TaskContext } from "compose";
 import { Wallet } from "@ethersproject/wallet";
-import { OrderBuilder } from "@polymarket/clob-client/dist/order-builder/builder.js";
-import { orderToJson } from "@polymarket/clob-client/dist/utilities.js";
-import { Side, OrderType, SignatureType } from "@polymarket/clob-client";
-import type { TickSize } from "@polymarket/clob-client";
-import { createL1Headers, createL2Headers } from "@polymarket/clob-client/dist/headers/index.js";
+import {
+  OrderBuilder,
+  Side,
+  OrderType,
+  SignatureTypeV2,
+  createL1Headers,
+  createL2Headers,
+  orderToJsonV2,
+  type TickSize,
+} from "@polymarket/clob-client-v2";
 
 const CHAIN_ID = 137;
+/** V2 order version. SDK supports both V1 and V2 markets during the migration. */
+const ORDER_VERSION = 2;
 
 type ApiCreds = { key: string; secret: string; passphrase: string };
 
@@ -81,7 +88,7 @@ export type TradeResult = {
 };
 
 /**
- * Build, sign, and submit a FAK (Fill-and-Kill) market order to the CLOB.
+ * Build, sign, and submit a FAK (Fill-and-Kill) market order to the V2 CLOB.
  * All HTTP goes through ctx.fetch to the host → proxy → CLOB.
  */
 export async function executeTrade(
@@ -94,7 +101,6 @@ export async function executeTrade(
   whalePrice: number,
   tickSize: string,
   negRisk: boolean,
-  feeRateBps: number,
   sellSize?: number
 ): Promise<TradeResult> {
   try {
@@ -117,8 +123,8 @@ export async function executeTrade(
       return { success: false, error: `size too small (${shares})` };
     }
 
-    // SDK's `amount` param for createMarketOrder:
-    //   BUY: USDC to spend (shares * price)
+    // SDK's `amount` param for buildMarketOrder:
+    //   BUY: pUSD to spend (shares * price)
     //   SELL: shares to sell
     const amount = side === "BUY" ? shares * price : shares;
 
@@ -126,7 +132,7 @@ export async function executeTrade(
     const builder = new OrderBuilder(
       wallet as any,
       CHAIN_ID,
-      SignatureType.EOA
+      SignatureTypeV2.EOA
     );
 
     console.log(
@@ -140,13 +146,13 @@ export async function executeTrade(
         price,
         amount,
         side: side === "BUY" ? Side.BUY : Side.SELL,
-        feeRateBps,
       } as any,
-      { tickSize: tickSize as TickSize, negRisk }
+      { tickSize: tickSize as TickSize, negRisk },
+      ORDER_VERSION
     );
 
     const creds = await getApiCreds(ctx, privateKey, host);
-    const body = orderToJson(signedOrder, creds.key, OrderType.FAK);
+    const body = orderToJsonV2(signedOrder as any, creds.key, OrderType.FAK);
     const bodyStr = JSON.stringify(body);
 
     const l2Headers = await createL2Headers(

--- a/compose/copy-trader/src/lib/gamma.ts
+++ b/compose/copy-trader/src/lib/gamma.ts
@@ -35,7 +35,6 @@ export async function lookupMarketByTokenId(
       negRisk: m.negRisk === true,
       enableOrderBook: m.enableOrderBook === true,
       closed: m.closed === true,
-      feeRateBps: m.takerBaseFee ?? 0,
       outcomePrices: [
         parseFloat(outcomePrices[0]) || 0,
         parseFloat(outcomePrices[1]) || 0,

--- a/compose/copy-trader/src/lib/types.ts
+++ b/compose/copy-trader/src/lib/types.ts
@@ -1,14 +1,22 @@
-/** Polymarket contract addresses on Polygon */
+/**
+ * Polymarket V2 contract addresses on Polygon.
+ * V2 cutover: 2026-04-28 (https://docs.polymarket.com/v2-migration).
+ *
+ * Collateral is pUSD (a 1:1 wrapper around USDC.e). Users fund their wallet
+ * with USDC.e and `setup_approvals` wraps it via the Collateral Onramp.
+ */
 export const CONTRACTS = {
-  ctfExchange: "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E",
-  negRiskExchange: "0xC5d563A36AE78145C45a50134d48A1215220f80a",
+  ctfExchangeV2: "0xE111180000d2663C0091e4f400237545B87B996B",
+  negRiskExchangeV2: "0xe2222d279d744050d28e00520010520000310F59",
   conditionalTokens: "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045",
+  collateralOnramp: "0x93070a847efEf7F70739046A929D47a521F5B8ee",
+  pUSD: "0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB",
   usdc: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
 } as const;
 
 export const CHAIN_ID = 137;
 
-/** Row from the Turbo pipeline's order_fills sink */
+/** Row from the Turbo pipeline's order_fills sink (V2 OrderFilled event). */
 export type OrderFillRow = {
   id: string;
   block_number: number;
@@ -17,9 +25,12 @@ export type OrderFillRow = {
   block_timestamp: string;
   maker: string;
   taker: string;
-  maker_asset_id: string;
-  taker_asset_id: string;
+  /** Maker's side. "0" = BUY (maker pays pUSD for shares), "1" = SELL. */
+  side: string;
+  token_id: string;
+  /** Decimal pUSD (6 decimals applied). */
   maker_amount: number;
+  /** Decimal pUSD or shares depending on side. */
   taker_amount: number;
   fee: number;
 };
@@ -58,8 +69,6 @@ export type MarketInfo = {
   negRisk: boolean;
   enableOrderBook: boolean;
   closed: boolean;
-  feeRateBps: number;
   outcomePrices: [number, number];
   clobTokenIds: [string, string];
 };
-

--- a/compose/copy-trader/src/tasks/copy_trade.ts
+++ b/compose/copy-trader/src/tasks/copy_trade.ts
@@ -1,13 +1,14 @@
 /**
  * copy_trade — HTTP-triggered by Turbo pipeline webhook
  *
- * Receives a decoded OrderFilled event row from the pipeline.
+ * Receives a decoded V2 OrderFilled event row from the pipeline.
  * Determines buy/sell side, looks up market via Gamma, places CLOB order.
  */
 import type { TaskContext } from "compose";
 import { privateKeyToAccount } from "viem/accounts";
 import { executeTrade } from "../lib/clob";
 import { lookupMarketByTokenId } from "../lib/gamma";
+import { CONTRACTS } from "../lib/types";
 import type { OrderFillRow, Position, Trade } from "../lib/types";
 
 export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
@@ -39,9 +40,9 @@ export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
   const positionsCollection = await ctx.collection<Position>("positions");
   const tradesCollection = await ctx.collection<Trade>("trades");
 
-  // Budget check: read USDC.e balance on-chain (source of truth). If we don't
-  // have enough for the $1 minimum notional, skip. This avoids the local
-  // budget counter drifting out of sync with the real wallet.
+  // Budget check: read pUSD balance on-chain (V2 collateral, source of truth).
+  // If we don't have enough for the $1 minimum notional, skip. This avoids the
+  // local budget counter drifting out of sync with the real wallet.
   if (side === "BUY") {
     const pk = ctx.env.PRIVATE_KEY as `0x${string}`;
     const address = privateKeyToAccount(
@@ -57,7 +58,7 @@ export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
           method: "eth_call",
           params: [
             {
-              to: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+              to: CONTRACTS.pUSD,
               data: "0x70a08231000000000000000000000000" + address.slice(2).toLowerCase(),
             },
             "latest",
@@ -66,10 +67,10 @@ export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
         }),
       }
     )) as { result?: string };
-    const usdcBalance = balResp?.result ? Number(BigInt(balResp.result)) / 1e6 : 0;
-    if (usdcBalance < 1.1) {
-      console.log(`[copy_trade] BALANCE_LOW: $${usdcBalance.toFixed(2)} (need >=$1.10)`);
-      return { status: "BALANCE_LOW", balance: usdcBalance };
+    const pusdBalance = balResp?.result ? Number(BigInt(balResp.result)) / 1e6 : 0;
+    if (pusdBalance < 1.1) {
+      console.log(`[copy_trade] BALANCE_LOW: ${pusdBalance.toFixed(2)} pUSD (need >=1.10). Run setup_approvals to wrap USDC.e → pUSD.`);
+      return { status: "BALANCE_LOW", balance: pusdBalance };
     }
   }
 
@@ -124,7 +125,6 @@ export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
     whalePrice,
     market.tickSize,
     market.negRisk,
-    market.feeRateBps,
     sellSize
   );
 
@@ -197,17 +197,14 @@ export async function main(ctx: TaskContext, params?: Record<string, unknown>) {
 }
 
 /**
- * Parse an OrderFilled webhook payload to determine trade direction.
+ * Parse a V2 OrderFilled webhook payload to determine trade direction.
  *
- * CTF Exchange OrderFilled:
- *   maker gives makerAsset of makerAmountFilled
- *   taker gives takerAsset of takerAmountFilled
- *   asset_id "0" = USDC (collateral), anything else = CTF share token
+ * V2 OrderFilled emits the MAKER's side (0 = BUY, 1 = SELL) and a single
+ * `tokenId` (no more makerAssetId/takerAssetId pair). The whale we want to
+ * copy may be the maker or the taker — taker takes the opposite side.
  *
- * The side we care about (BUY vs SELL) is the action the WATCHED WALLET is taking.
- * The pipeline filters to trades where maker OR taker is a watched wallet.
- *
- * Price = USDC amount / shares amount (always in [0,1] for valid fills).
+ * Price = pUSD amount / shares amount. For a BUY-side maker, makerAmount is
+ * pUSD and takerAmount is shares; for a SELL-side maker it's reversed.
  */
 function parseFill(
   row: OrderFillRow,
@@ -216,30 +213,31 @@ function parseFill(
   const makerIsWhale = watchedWallets.has(row.maker.toLowerCase());
   const takerIsWhale = watchedWallets.has(row.taker.toLowerCase());
 
-  // Figure out which side is USDC and which is shares
-  const makerIsUsdc = row.maker_asset_id === "0";
-  const takerIsUsdc = row.taker_asset_id === "0";
+  // Maker's side as encoded in the event (uint8): "0" = BUY, "1" = SELL.
+  const makerSide: "BUY" | "SELL" = row.side === "0" ? "BUY" : "SELL";
+  const oppositeSide: "BUY" | "SELL" = makerSide === "BUY" ? "SELL" : "BUY";
 
-  if (!makerIsUsdc && !takerIsUsdc) {
-    // Share-for-share swap, shouldn't happen in normal flow
+  // Whichever side the whale is on, set their effective side.
+  let whaleSide: "BUY" | "SELL";
+  if (makerIsWhale) {
+    whaleSide = makerSide;
+  } else if (takerIsWhale) {
+    whaleSide = oppositeSide;
+  } else {
+    // Shouldn't happen — pipeline filters to fills involving a watched wallet.
     return { side: "BUY", tokenId: "", whalePrice: 0 };
   }
 
-  // Identify share token and its amount, plus the USDC amount
-  const shareTokenId = makerIsUsdc ? row.taker_asset_id : row.maker_asset_id;
-  const sharesAmount = makerIsUsdc ? row.taker_amount : row.maker_amount;
-  const usdcAmount = makerIsUsdc ? row.maker_amount : row.taker_amount;
+  // Compute price: pUSD per share. Layout depends on the maker's side.
+  //   makerSide = BUY:  makerAmount = pUSD,   takerAmount = shares
+  //   makerSide = SELL: makerAmount = shares, takerAmount = pUSD
+  const usdcAmount = makerSide === "BUY" ? row.maker_amount : row.taker_amount;
+  const sharesAmount = makerSide === "BUY" ? row.taker_amount : row.maker_amount;
   const price = sharesAmount > 0 ? usdcAmount / sharesAmount : 0;
 
-  // Whoever gives USDC is buying shares. Determine if watched wallet is the buyer.
-  const usdcGiver = makerIsUsdc ? "maker" : "taker";
-  const whaleIsUsdcGiver =
-    (usdcGiver === "maker" && makerIsWhale) ||
-    (usdcGiver === "taker" && takerIsWhale);
-
   return {
-    side: whaleIsUsdcGiver ? "BUY" : "SELL",
-    tokenId: shareTokenId,
+    side: whaleSide,
+    tokenId: row.token_id,
     whalePrice: price,
   };
 }

--- a/compose/copy-trader/src/tasks/redeem.ts
+++ b/compose/copy-trader/src/tasks/redeem.ts
@@ -5,6 +5,14 @@
  * calls redeemPositions() on-chain for each. Polymarket marks a position
  * `redeemable: true` when its condition has resolved on-chain.
  *
+ * V2 markets are collateralized in pUSD, so redemption is denominated in
+ * pUSD. Pre-V2 (USDC.e collateralized) positions need a different collateral
+ * arg — see note below — but new positions opened by this bot are all V2.
+ *
+ * NegRisk markets redeem via the NegRiskAdapter (different ABI), not the
+ * ConditionalTokens contract. We skip them here and log a TODO; the basic
+ * (non-NegRisk) path is what the example demonstrates.
+ *
  * This intentionally doesn't use the local `positions` collection — the data
  * API is the source of truth and already knows the conditionId + outcomeIndex
  * for every share we hold, including trades that happened before this task
@@ -25,6 +33,7 @@ type DataApiPosition = {
   size: number;
   currentValue: number;
   redeemable: boolean;
+  negRisk?: boolean;
   // Multi-outcome markets have outcomeCount > 2; binary markets have 2.
   // For a binary market, indexSets are: outcome 0 → 1, outcome 1 → 2.
 };
@@ -72,6 +81,15 @@ export async function main(ctx: TaskContext) {
     if (seenConditions.has(pos.conditionId)) continue;
     seenConditions.add(pos.conditionId);
 
+    // NegRisk markets settle via NegRiskAdapter, not ConditionalTokens —
+    // out of scope for this example.
+    if (pos.negRisk) {
+      console.log(
+        `[redeem] SKIP NegRisk ${pos.conditionId.slice(0, 12)}... (${pos.title.slice(0, 40)}) — needs NegRiskAdapter.redeemPositions`
+      );
+      continue;
+    }
+
     // Binary market: indexSet 1 = outcome 0 (YES), indexSet 2 = outcome 1 (NO).
     // Passing both [1, 2] redeems whatever we hold in one call.
     const indexSets = [1, 2];
@@ -84,7 +102,7 @@ export async function main(ctx: TaskContext) {
         ctx.evm.chains.polygon,
         CONTRACTS.conditionalTokens as `0x${string}`,
         CONDITIONAL_TOKENS_ABI,
-        [CONTRACTS.usdc, parentCollectionId, pos.conditionId, indexSets]
+        [CONTRACTS.pUSD, parentCollectionId, pos.conditionId, indexSets]
       );
       console.log(`[redeem] redeemed: ${tx.hash}`);
       results.push({ condition: pos.conditionId, tx: tx.hash });

--- a/compose/copy-trader/src/tasks/setup_approvals.ts
+++ b/compose/copy-trader/src/tasks/setup_approvals.ts
@@ -1,9 +1,19 @@
 /**
  * setup_approvals — HTTP-triggered, run once after funding the wallet
+ * (and again after every USDC.e top-up).
  *
- * Grants USDC + ConditionalTokens approvals to Polymarket's exchange contracts.
- * Required once before the bot can trade. Uses Compose's sponsored gas, so
- * the EOA doesn't need MATIC.
+ * V2 collateral flow: USDC.e → wrap via Collateral Onramp → pUSD → trade.
+ *
+ * This task:
+ *   1. Approves USDC.e to the Collateral Onramp (one-time, max).
+ *   2. Wraps the wallet's full USDC.e balance into pUSD.
+ *   3. Approves pUSD to both V2 Exchanges (so they can spend it on BUYs).
+ *   4. Approves ConditionalTokens to both V2 Exchanges (for SELLs).
+ *
+ * Idempotent: re-call any time. Approvals are max so re-approving is a no-op
+ * on-chain; wrap() is a no-op when USDC.e balance is zero.
+ *
+ * Compose sponsors gas, so the EOA doesn't need MATIC.
  *
  * Call: curl -X POST -H "Authorization: Bearer $COMPOSE_TOKEN" \
  *   https://api.goldsky.com/api/admin/compose/v1/copy-trader/tasks/setup_approvals
@@ -16,35 +26,80 @@ const MAX_UINT256 =
 
 const ERC20_APPROVE_ABI = "approve(address,uint256)";
 const ERC1155_SET_APPROVAL_ABI = "setApprovalForAll(address,bool)";
+const ONRAMP_WRAP_ABI = "wrap(address,address,uint256)";
 
 export async function main(ctx: TaskContext) {
+  const pk = ctx.env.PRIVATE_KEY as `0x${string}`;
   const wallet = await ctx.evm.wallet({
     name: "copy-trader",
-    privateKey: ctx.env.PRIVATE_KEY as `0x${string}`,
+    privateKey: pk,
     sponsorGas: true,
   });
 
   const exchanges = [
-    { name: "CTF Exchange", address: CONTRACTS.ctfExchange },
-    { name: "NegRisk Exchange", address: CONTRACTS.negRiskExchange },
+    { name: "CTF Exchange V2", address: CONTRACTS.ctfExchangeV2 },
+    { name: "NegRisk Exchange V2", address: CONTRACTS.negRiskExchangeV2 },
   ];
 
   const results: Array<{ name: string; type: string; tx: string }> = [];
 
-  // USDC.e (ERC-20) approvals — let each exchange spend our USDC
+  // 1. USDC.e (ERC-20) → Collateral Onramp (so it can wrap on our behalf)
+  console.log(`[setup_approvals] Approving USDC.e for Collateral Onramp`);
+  const usdcApproveTx = await wallet.writeContract(
+    ctx.evm.chains.polygon,
+    CONTRACTS.usdc as `0x${string}`,
+    ERC20_APPROVE_ABI,
+    [CONTRACTS.collateralOnramp, MAX_UINT256]
+  );
+  console.log(`[setup_approvals] USDC.e approved for Onramp: ${usdcApproveTx.hash}`);
+  results.push({ name: "Collateral Onramp", type: "USDC.e", tx: usdcApproveTx.hash });
+
+  // 2. Wrap whatever USDC.e the wallet currently holds into pUSD
+  const balResp = (await ctx.fetch("https://polygon-bor-rpc.publicnode.com", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "eth_call",
+      params: [
+        {
+          to: CONTRACTS.usdc,
+          data: "0x70a08231000000000000000000000000" + wallet.address.slice(2).toLowerCase(),
+        },
+        "latest",
+      ],
+      id: 1,
+    }),
+  })) as { result?: string };
+  const usdcBalRaw = balResp?.result ? BigInt(balResp.result) : 0n;
+  if (usdcBalRaw > 0n) {
+    console.log(`[setup_approvals] Wrapping ${Number(usdcBalRaw) / 1e6} USDC.e → pUSD`);
+    const wrapTx = await wallet.writeContract(
+      ctx.evm.chains.polygon,
+      CONTRACTS.collateralOnramp as `0x${string}`,
+      ONRAMP_WRAP_ABI,
+      [CONTRACTS.usdc, wallet.address, usdcBalRaw]
+    );
+    console.log(`[setup_approvals] Wrapped: ${wrapTx.hash}`);
+    results.push({ name: "Collateral Onramp", type: "wrap", tx: wrapTx.hash });
+  } else {
+    console.log(`[setup_approvals] No USDC.e balance to wrap`);
+  }
+
+  // 3. pUSD (ERC-20) → V2 Exchanges (so they can spend pUSD on BUYs)
   for (const ex of exchanges) {
-    console.log(`[setup_approvals] Approving USDC for ${ex.name}`);
+    console.log(`[setup_approvals] Approving pUSD for ${ex.name}`);
     const tx = await wallet.writeContract(
       ctx.evm.chains.polygon,
-      CONTRACTS.usdc as `0x${string}`,
+      CONTRACTS.pUSD as `0x${string}`,
       ERC20_APPROVE_ABI,
       [ex.address, MAX_UINT256]
     );
-    console.log(`[setup_approvals] USDC approved for ${ex.name}: ${tx.hash}`);
-    results.push({ name: ex.name, type: "USDC", tx: tx.hash });
+    console.log(`[setup_approvals] pUSD approved for ${ex.name}: ${tx.hash}`);
+    results.push({ name: ex.name, type: "pUSD", tx: tx.hash });
   }
 
-  // ConditionalTokens (ERC-1155) approvals — let each exchange move our share tokens
+  // 4. ConditionalTokens (ERC-1155) → V2 Exchanges (for SELLs and redemption flow)
   for (const ex of exchanges) {
     console.log(`[setup_approvals] Approving ConditionalTokens for ${ex.name}`);
     const tx = await wallet.writeContract(


### PR DESCRIPTION
## Summary

Polymarket [migrated to V2](https://docs.polymarket.com/v2-migration) on 2026-04-28: new Exchange contracts on Polygon, USDC.e → pUSD collateral switch, and a new SDK at \`@polymarket/clob-client-v2\`. The pre-cutover copy-trader example no longer works — pipeline watches dead addresses, OrderFilled ABI changed, and orders signed with the V1 SDK are rejected.

This PR brings the example back to working order, end-to-end, on V2.

## Changes

- **Pipeline** (\`pipeline/polymarket-ctf-events.yaml\`): V2 Exchange addresses (\`0xE111…996B\`, \`0xe222…0F59\`) and new OrderFilled ABI — single \`tokenId\`, explicit \`uint8 side\`, plus \`builder\`/\`metadata\` bytes32 fields. SQL parsing simplified accordingly.
- **SDK** (\`src/lib/clob.ts\`): \`@polymarket/clob-client@5\` → \`@polymarket/clob-client-v2@1.0.2\`. Uses \`OrderBuilder\` with \`SignatureTypeV2.EOA\`, passes \`version=2\` to \`buildMarketOrder\`, calls \`orderToJsonV2\`. \`feeRateBps\` dropped (fees computed on-chain in V2).
- **Collateral** (\`src/tasks/setup_approvals.ts\`): now approves USDC.e → Collateral Onramp, wraps the wallet's USDC.e balance into pUSD, and approves pUSD + ConditionalTokens to both V2 Exchanges. Idempotent on re-call (max approvals + wrap-if-balance-positive).
- **Balance check** (\`src/tasks/copy_trade.ts\`): USDC.e → pUSD (\`0xC011…2DFB\`, still 6 decimals).
- **parseFill** (\`src/tasks/copy_trade.ts\`): V2 emits the maker's side directly (\`uint8\` 0=BUY/1=SELL), so no more asset-id-zero inference. Whale-as-taker takes the opposite side.
- **Redemption** (\`src/tasks/redeem.ts\`): pUSD as the collateral arg to \`redeemPositions\`. NegRisk markets are explicitly skipped (need \`NegRiskAdapter.redeemPositions\`, out of scope for this example).
- **README**: funding flow updated (USDC.e → wrap → pUSD), V2 contract address table.

## Verified

- \`tsc --noEmit\` clean
- \`esbuild --platform=node --format=iife\` (matches \`compose/src/cli.ts:83-95\`) bundles all three tasks without errors
- Cross-checked addresses, EIP-712 domain, SDK exports, wrap signature against the V2 migration docs and the V2 contract source

## Not verified

- End-to-end deploy + funded EOA + watched whale fill. Code is reviewed but not run on real V2 markets yet.

## Test plan
- [ ] Deploy to a test project: \`goldsky compose deploy\` + \`goldsky turbo apply pipeline/polymarket-ctf-events.yaml\`
- [ ] Fund EOA with USDC.e, run \`setup_approvals\`, confirm USDC.e → pUSD wrap on Polygonscan
- [ ] Confirm pUSD balance on chain matches the wrapped amount
- [ ] Wait for a watched-wallet fill, confirm the bot mirrors it on V2 CLOB

🤖 Generated with [Claude Code](https://claude.com/claude-code)