### PR TITLE
vrf: make the example RandomnessConsumer permissionless to fulfill

### DIFF
--- a/compose/VRF/contracts/RandomnessConsumer.sol
+++ b/compose/VRF/contracts/RandomnessConsumer.sol
@@ -84,7 +84,12 @@ contract RandomnessConsumer {
 
     /**
      * @notice Fulfill a randomness request with drand proof data
-     * @dev Only callable by the authorized fulfiller (Compose wallet)
+     * @dev Permissionless: any caller may fulfill so the shared example
+     *      contract is reusable by anyone without being whitelisted. Trust does
+     *      not come from the caller's identity, it comes from the stored drand
+     *      `round` + `signature`, which anyone can verify off-chain against the
+     *      drand quicknet BLS public key documented above. The `fulfiller` field
+     *      is retained only as an informational deploy-time label.
      * @param requestId The request to fulfill
      * @param randomness The random value (sha256 of signature)
      * @param round The drand round number
@@ -96,8 +101,6 @@ contract RandomnessConsumer {
         uint64 round,
         bytes calldata signature
     ) external {
-        if (msg.sender != fulfiller) revert OnlyFulfiller();
-
         RandomnessRequest storage request = requests[requestId];
         if (request.requester == address(0)) revert RequestNotFound();
         if (request.fulfilled) revert AlreadyFulfilled();


### PR DESCRIPTION
Removes the `OnlyFulfiller` gate on `fulfillRandomness` in the VRF example contract so the shared example consumer is reusable by anyone, without being whitelisted.

## Why
The Goldsky chatbot seed prompts (goldsky-io/goldsky#4861, FOU-821) now recommend "reuse the shared example contract, no deploy needed" as the default path. For VRF that only works if the consumer accepts a fulfill call from any Compose wallet, not just the address fixed at deploy. This makes the canonical source match that promise.

## What changed
- `fulfillRandomness` no longer reverts with `OnlyFulfiller`; any caller may fulfill.
- Trust is unchanged in substance: it comes from the stored drand `round` + BLS `signature`, which anyone verifies off-chain against the drand quicknet public key (documented in the contract). Identity of the caller was never the security boundary.
- `fulfiller` is kept as an informational deploy-time label and `setFulfiller` stays gated, so the **ABI is unchanged** and the generated bindings stay valid.

## Scope / caveats
- **Source-only. No redeploy.** The live demo at `0xE05Ceb3E269029E3bab46E35515e8987060D1027` (Base Sepolia) is untouched and remains the old gated version until someone redeploys this open one. Reuse of the live address becomes functional only after that redeploy.
- The VRF setup SKILL.md and README still describe the current gated deploy flow ("the fulfiller must be your Compose wallet", "shared contract is not reusable"). Those are accurate for the live contract today and should be reconciled alongside the redeploy in the **FOU-725 VRF demo revamp**, to avoid conflicting with that in-flight work.
- bitcoin-oracle has no contract source in this repo (only the ABI), and its on-chain `write` is already open; corporate-actions' per-campaign operator gating is intended multi-tenant design, not a global whitelist. So no other example contract needed changes.