### PR TITLE
compose: point oracle/VRF at open demo contracts + default corporate-actions to Base Sepolia

### DIFF
--- a/compose/VRF/compose.yaml
+++ b/compose/VRF/compose.yaml
@@ -22,6 +22,10 @@ tasks:
     triggers:
       - type: "onchain_event"
         network: "base_sepolia"
+        # No-deploy option: to try this without deploying your own contract, use
+        # the totally open RandomnessConsumer on Base Sepolia (anyone can fulfill):
+        # 0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d. Keep this in sync with
+        # CONTRACT_ADDRESS in src/tasks/request-randomness.ts and fulfill-randomness.ts.
         contract: "0xE05Ceb3E269029E3bab46E35515e8987060D1027"
         events:
           - "RandomnessRequested(uint256,address)"

--- a/compose/VRF/src/tasks/fulfill-randomness.ts
+++ b/compose/VRF/src/tasks/fulfill-randomness.ts
@@ -7,6 +7,12 @@ import {
   DRAND_CHAIN_INFO,
 } from "../lib/drand.ts";
 
+// Address of your deployed RandomnessConsumer (see README to deploy your own).
+// No-deploy option: to get this running and see it all working without
+// deploying anything, point this at the totally open RandomnessConsumer on Base
+// Sepolia, where anyone can fulfill (no fulfiller gate):
+// 0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d. Keep this in sync with the
+// CONTRACT_ADDRESS in request-randomness.ts and the `contract:` field in compose.yaml.
 const CONTRACT_ADDRESS = "0xE05Ceb3E269029E3bab46E35515e8987060D1027";
 
 /**

--- a/compose/VRF/src/tasks/request-randomness.ts
+++ b/compose/VRF/src/tasks/request-randomness.ts
@@ -1,5 +1,11 @@
 import { TaskContext } from "compose";
 
+// Address of your deployed RandomnessConsumer (see README to deploy your own).
+// No-deploy option: to get this running and see it all working without
+// deploying anything, point this at the totally open RandomnessConsumer on Base
+// Sepolia, where anyone can fulfill (no fulfiller gate):
+// 0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d. Keep this in sync with the
+// CONTRACT_ADDRESS in fulfill-randomness.ts and the `contract:` field in compose.yaml.
 const CONTRACT_ADDRESS = "0xE05Ceb3E269029E3bab46E35515e8987060D1027";
 
 export async function main(context: TaskContext): Promise<{

--- a/compose/bitcoin-oracle/src/tasks/bitcoin-oracle.ts
+++ b/compose/bitcoin-oracle/src/tasks/bitcoin-oracle.ts
@@ -2,6 +2,13 @@ import { TaskContext } from "compose";
 
 import { toBytes32 } from "../lib/utils";
 
+// PriceOracle this task writes to. By default you deploy your own (see README);
+// the address below is on Polygon Amoy (the chain set just below).
+// No-deploy option: if you just want to get this running and watch the
+// PriceUpdated events without deploying anything, there is a totally open
+// PriceOracle on Base Sepolia (no access control, anyone can write) at
+// 0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113. To use it, set ORACLE_CONTRACT to
+// that address and change evm.chains.polygonAmoy below to evm.chains.baseSepolia.
 const ORACLE_CONTRACT = "0x34a264BCD26e114eD6C46a15d0A3Ba1873CaA708";
 
 export async function main(context: TaskContext) {


### PR DESCRIPTION
Makes the demo contracts in the compose examples usable without forcing a deploy or real gas.

**bitcoin-oracle + VRF** (comments only, defaults unchanged): adds a note next to each contract address pointing at a totally open (permissionless) contract on Base Sepolia, so users can point at these instead of deploying anything.
- PriceOracle (open `write`): `0x53deB3fF6E6e82A3b5E96f14E185e3Fe66BF5113`
- RandomnessConsumer (open `fulfillRandomness`): `0x6273AB73C95Ba2233281F1eb8aa3b21D9352AD6d`

**corporate-actions** (default switched): the example now defaults to shared permissionless contracts on Base Sepolia (no real gas), with the Base mainnet addresses kept as a commented option in `constants.ts`. Also splits the overloaded `CONFIG.chain` into `chain` (evm.chains key) and `turboChain` (Turbo dataset prefix) since Base Sepolia differs across the two (`baseSepolia` vs `base_sepolia`).
- MockUSDC (open `mint`): `0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE`
- ShareToken: `0x713e0749a9Fe480322990913850e81b0F4F4dc0d` (block 42275958)
- DistributionCampaign (open `declare()`): `0xA8e58573B1e10908b63d12B603aCF9C784BF904E`

All contracts deployed and smoke-tested on Base Sepolia (oracle `write`, VRF `fulfillRandomness`, and the full corporate-actions mint -> approve -> declare from a plain wallet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)