### PR TITLE
corporate-actions: default to permissionless Base Sepolia demo contracts

### DIFF
--- a/compose/corporate-actions/README.md
+++ b/compose/corporate-actions/README.md
@@ -55,7 +55,7 @@ In real corporate actions, the **record date** is set in advance and is the cuto
 
 - [Goldsky CLI](https://docs.goldsky.com/installation), authenticated against your project
 - [Foundry](https://book.getfoundry.sh/getting-started/installation) for the contract deploys
-- A small amount of ETH on Base mainnet for the contract deploys (~0.0005 ETH)
+- A small amount of Base Sepolia ETH, only if you deploy your own contracts (~0.0005 ETH). The repo ships pointed at shared permissionless demo contracts, so you can skip the deploy entirely.
 - A project API key for the Compose CLI (`goldsky compose deploy -t <key>`) and a separate (or same) key set as the `GOLDSKY_PROJECT_KEY` secret so the running app can manage Turbo pipelines
 
 ## Project structure
@@ -88,13 +88,15 @@ corporate-actions/
 
 ## Quick start
 
-### 1. Deploy the contracts
+This repo ships pointed at shared, permissionless demo contracts on Base Sepolia (see `src/lib/constants.ts`): MockUSDC has an open `mint` and DistributionCampaign has an open `declare()`, so anyone can run their own campaign on them. To just see it working, skip steps 1 and 4 and start at step 2. Deploy your own (step 1) only if you want an isolated instance, and see the comment in `src/lib/constants.ts` to run on Base mainnet instead.
+
+### 1. Deploy the contracts (optional)
 
 ```bash
 PRIVATE_KEY=0x... ./scripts/deploy.sh
 ```
 
-Deploys MockUSDC, ShareToken (pre-minting to the 25 seed holders), and DistributionCampaign on Base mainnet. Prints the three addresses and the ShareToken deploy block; copy them into `src/lib/constants.ts`.
+Deploys MockUSDC, ShareToken (pre-minting to the 25 seed holders), and DistributionCampaign on Base Sepolia. Prints the three addresses and the ShareToken deploy block; copy them into `src/lib/constants.ts`.
 
 ### 2. Set the project secret
 
@@ -118,7 +120,7 @@ The operator wallet address is printed in the compose app's logs on first reques
 
 ```bash
 cast send <MOCK_USDC> "mint(address,uint256)" <OPERATOR> 1000000000000 \
-  --rpc-url https://mainnet.base.org --private-key $PRIVATE_KEY
+  --rpc-url https://sepolia.base.org --private-key $PRIVATE_KEY
 ```
 
 (1,000,000 mUSDC.)
@@ -128,7 +130,7 @@ cast send <MOCK_USDC> "mint(address,uint256)" <OPERATOR> 1000000000000 \
 Pick a record block past finality:
 
 ```bash
-RECORD_BLOCK=$(cast block-number --rpc-url https://mainnet.base.org)
+RECORD_BLOCK=$(cast block-number --rpc-url https://sepolia.base.org)
 RECORD_BLOCK=$((RECORD_BLOCK - 32))
 
 curl -sX POST "https://api.goldsky.com/api/admin/compose/v1/corporate-actions/tasks/declare_campaign" \
@@ -147,7 +149,7 @@ That declares a 10,000 mUSDC distribution. The request stays open for ~10-30 sec
 
 ```bash
 cast call <DISTRIBUTION_CAMPAIGN> "getCampaign(bytes32)" <onChainId> \
-  --rpc-url https://mainnet.base.org
+  --rpc-url https://sepolia.base.org
 ```
 
 `escrowRemaining` will be exactly 0 once all 25 holders are paid. The full audit trail is in the contract's `HolderPaid` events.

--- a/compose/corporate-actions/scripts/deploy.sh
+++ b/compose/corporate-actions/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Deploy contracts to Base mainnet.
+# Deploy contracts to Base Sepolia by default (override RPC_URL for Base mainnet).
 #
 # Usage:
 #   PRIVATE_KEY=0x... ./scripts/deploy.sh                  # all three (initial setup)
@@ -14,7 +14,7 @@
 # src/lib/constants.ts (shareToken + shareTokenDeployBlock).
 #
 # Defaults can be overridden:
-#   RPC_URL=...                  (default: https://mainnet.base.org)
+#   RPC_URL=...                  (default: https://sepolia.base.org)
 #   HOLDERS_FILE=...             (default: scripts/seed-holders.json)
 
 set -euo pipefail
@@ -26,11 +26,11 @@ case "$MODE" in
 esac
 
 if [[ -z "${PRIVATE_KEY:-}" ]]; then
-  echo "PRIVATE_KEY env var required (deployer wallet, must hold a small amount of ETH on Base)" >&2
+  echo "PRIVATE_KEY env var required (deployer wallet, must hold a small amount of Base Sepolia ETH)" >&2
   exit 1
 fi
 
-RPC_URL="${RPC_URL:-https://mainnet.base.org}"
+RPC_URL="${RPC_URL:-https://sepolia.base.org}"
 HOLDERS_FILE="${HOLDERS_FILE:-scripts/seed-holders.json}"
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 

--- a/compose/corporate-actions/src/lib/constants.ts
+++ b/compose/corporate-actions/src/lib/constants.ts
@@ -1,17 +1,28 @@
 import type { Hex } from "./types";
 
 /**
- * Single-chain demo on Base mainnet. Each declaration spawns its own
+ * Single-chain demo on Base Sepolia. Each declaration spawns its own
  * job-mode Turbo pipeline, so there's nothing chain-specific to configure
  * beyond the deployed contract addresses below.
+ *
+ * Defaults to Base Sepolia so the demo costs no real gas and uses the shared
+ * permissionless contracts below (open mint on MockUSDC, open declare() on the
+ * campaign). To run on Base mainnet instead, swap in these values (real gas
+ * applies):
+ *   chain: "base", turboChain: "base",
+ *   shareToken:        "0xE05Ceb3E269029E3bab46E35515e8987060D1027",
+ *   payToken (MockUSDC): "0x02D9Df62B7AED15739D638B92BAcEA2ce4Cb3d70",
+ *   campaignContract:  "0x81051f77ea167b631Dd7F40ac414A9F9344Fb162",
+ *   shareTokenDeployBlock: 45654954,
  *
  * Update after running `scripts/deploy.sh`.
  */
 export const CONFIG = {
-  chain: "base" as const,            // matches evm.chains[chain] AND turbo dataset prefix
-  shareToken:       "0xE05Ceb3E269029E3bab46E35515e8987060D1027" as Hex,
-  payToken:         "0x02D9Df62B7AED15739D638B92BAcEA2ce4Cb3d70" as Hex,  // MockUSDC
-  campaignContract: "0x81051f77ea167b631Dd7F40ac414A9F9344Fb162" as Hex,
+  chain:      "baseSepolia" as const,   // evm.chains[chain] key (camelCase)
+  turboChain: "base_sepolia",           // Turbo dataset prefix (snake_case network slug)
+  shareToken:       "0x713e0749a9Fe480322990913850e81b0F4F4dc0d" as Hex,
+  payToken:         "0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE" as Hex,  // MockUSDC (permissionless mint)
+  campaignContract: "0xA8e58573B1e10908b63d12B603aCF9C784BF904E" as Hex,  // permissionless: anyone can declare()
   // Block at which `shareToken` was deployed. Job-mode forces
   // `start_at: earliest`, so we can't anchor the source there directly;
   // instead this is used as the lower bound in the snapshot pipeline's
@@ -19,7 +30,7 @@ export const CONFIG = {
   // the planner prune all pre-deploy blocks before scanning. Per Jeff: a
   // filter-level block range is meaningfully faster than a source-level
   // `end_block` alone.
-  shareTokenDeployBlock: 45654954,
+  shareTokenDeployBlock: 42275958,
 };
 
 /**

--- a/compose/corporate-actions/src/lib/turbo.ts
+++ b/compose/corporate-actions/src/lib/turbo.ts
@@ -94,7 +94,7 @@ export function buildSnapshotPipeline(input: {
     sources: {
       transfers: {
         type: "dataset",
-        dataset_name: `${CONFIG.chain}.erc20_transfers`,
+        dataset_name: `${CONFIG.turboChain}.erc20_transfers`,
         version: "1.2.0",
         // `start_at` MUST be 'earliest' for hybrid-source / job-mode
         // semantics. Setting it to a block number makes the source


### PR DESCRIPTION
Follow-up to #27, which merged before this commit landed (it included only the oracle/VRF no-deploy comments).

Switches the corporate-actions example default to shared permissionless contracts on Base Sepolia so running it costs no real gas, with the Base mainnet addresses kept as a commented option in `constants.ts`. Splits the overloaded `CONFIG.chain` into `chain` (evm.chains key, `baseSepolia`) and `turboChain` (Turbo dataset prefix, `base_sepolia`).

Deployed + smoke-tested on Base Sepolia (mint -> approve -> declare from a plain wallet):
- MockUSDC (open `mint`): `0x8ec24F07F08745fc3D979336AA81d4Dc73f3D9DE`
- ShareToken: `0x713e0749a9Fe480322990913850e81b0F4F4dc0d` (block 42275958)
- DistributionCampaign (open `declare()`): `0xA8e58573B1e10908b63d12B603aCF9C784BF904E`

🤖 Generated with [Claude Code](https://claude.com/claude-code)