### PR TITLE
compose: open-mint OpenShareToken demo contract + document copy-trader's separate pipeline

### DIFF
--- a/compose/copy-trader/compose.yaml
+++ b/compose/copy-trader/compose.yaml
@@ -21,6 +21,12 @@ env:
     GAMMA_HOST: "https://gamma-api.polymarket.com"
 
 tasks:
+  # copy_trade is fed by the separate Turbo pipeline (pipeline/polymarket-ctf-events.yaml),
+  # which pre-filters OrderFilled events to the watched wallets and webhooks this http task.
+  # We cannot use an onchain_event trigger here today because those triggers filter only by
+  # contract + event signature, not by indexed argument (maker / taker), so they would fire on
+  # every fill on the whole exchange (~3,000/min). Once onchain_event triggers support wallet
+  # filters, drop the pipeline and switch this task to an onchain_event trigger on the CTF Exchange.
   - name: "copy_trade"
     path: "./src/tasks/copy_trade.ts"
     triggers:

--- a/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
+++ b/compose/copy-trader/pipeline/polymarket-ctf-events.yaml
@@ -1,3 +1,15 @@
+# Why a separate Turbo pipeline instead of a Compose onchain_event trigger:
+# Compose onchain_event triggers filter only by contract address + event
+# signature. There is no way to filter by an indexed argument value (maker /
+# taker), and the CTF Exchange emits roughly 3,000 OrderFilled events per
+# minute across all traders. An onchain_event trigger would therefore invoke
+# the Compose task on every fill on the entire exchange and discard 99.99% of
+# them in code. This pipeline pre-filters to the watched wallets in-warehouse
+# (maker / taker IN ...) and webhooks only matching fills.
+#
+# Once onchain_event triggers support wallet (indexed-argument) filters, this
+# whole pipeline can be deleted and folded into a single onchain_event trigger
+# on the CTF Exchange contract in compose.yaml.
 name: polymarket-ctf-events
 resource_size: s
 description: "Index Polymarket V2 CTF Exchange fills for watched wallets → webhook to Compose"

--- a/compose/corporate-actions/contracts/OpenShareToken.sol
+++ b/compose/corporate-actions/contracts/OpenShareToken.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title OpenShareToken
+ * @notice 18-decimal demo share token with permissionless mint, suitable for testnet demos only.
+ * @dev Permissionless `mint` is intentional — anyone can mint shares to any address to build a
+ *      cap table for the dividend-distribution demo. Holder balances at a record block define
+ *      who gets paid. Do NOT use this contract in any production setting.
+ */
+contract OpenShareToken {
+    string public constant name = "Open Share Token";
+    string public constant symbol = "OSHARE";
+    uint8 public constant decimals = 18;
+
+    uint256 public totalSupply;
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    error InsufficientBalance();
+    error InsufficientAllowance();
+
+    /// @notice Permissionless mint — anyone can mint shares to any address. Demo only.
+    function mint(address to, uint256 value) external {
+        balanceOf[to] += value;
+        totalSupply += value;
+        emit Transfer(address(0), to, value);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        allowance[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 a = allowance[from][msg.sender];
+        if (a < value) revert InsufficientAllowance();
+        if (a != type(uint256).max) {
+            allowance[from][msg.sender] = a - value;
+        }
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        uint256 b = balanceOf[from];
+        if (b < value) revert InsufficientBalance();
+        unchecked {
+            balanceOf[from] = b - value;
+        }
+        balanceOf[to] += value;
+        emit Transfer(from, to, value);
+    }
+}


### PR DESCRIPTION
Follow-ups from the Compose chatbot seed-prompt work.

## corporate-actions: `OpenShareToken.sol`
An 18-decimal demo share token with a permissionless `mint(address,uint256)` (emits `Transfer`, so the cap-table snapshot pipeline can index it). Deployed to Base Sepolia at `0xCAA2c65b1A1526bdBA28cF7b32b0E0a59A88102a`. The dividend-distribution demo recommends it as the share token so anyone can mint themselves balances to build a cap table, distinct from the MockUSDC payout token. Testnet/demo only — permissionless mint is intentional and must never ship to production.

## copy-trader: why a separate Turbo pipeline
Comments in `compose.yaml` and `pipeline/polymarket-ctf-events.yaml` explain that the example uses a standalone Turbo pipeline rather than a Compose `onchain_event` trigger because those triggers filter only by contract + event signature (not by indexed `maker`/`taker`), and the CTF Exchange emits ~3,000 `OrderFilled`/min — so an `onchain_event` trigger would fire the task on every fill on the whole exchange. Once `onchain_event` triggers support wallet (indexed-arg) filters, the pipeline can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)